### PR TITLE
P argument in audapter_runFrames

### DIFF
--- a/speech/audapter_runFrames.m
+++ b/speech/audapter_runFrames.m
@@ -6,7 +6,11 @@ function [dataOut] = audapter_runFrames(data,p)
 %   returned by Audapter).
 
 % set Audapter param fields
-gender = 'female'; % dummy var for getting default params; overwritten by P if provided
+if ~isempty(p.gender)
+    gender = p.gender;
+else
+    gender = 'female'; % default gender is female
+end
 pDefault = getAudapterDefaultParams(gender);
 downFact = 3; % Downsampling factor
 fsNoDS = 48000; % Sampling rate, before downsampling
@@ -14,9 +18,6 @@ frameLenNoDS = 96;  % Frame length before downsampling (# of samples)
 pDefault.downFact = downFact;
 pDefault.sr = fsNoDS / downFact;
 pDefault.frameLen = frameLenNoDS / downFact;
-
-%pDefault.bShift = 0;
-%pDefault.nLPC = nlpc;
 
 if nargin < 2 
     p = pDefault;

--- a/speech/audapter_runFrames.m
+++ b/speech/audapter_runFrames.m
@@ -1,23 +1,29 @@
-function [dataOut] = audapter_runFrames(data,nlpc)
+function [dataOut] = audapter_runFrames(data,p)
 %AUDAPTER_RUNFRAMES  Process data in Audapter offline ('runFrame') mode.
-%   AUDAPTER_RUNFRAMES(DATA,NLPC) runs audio through Audapter's offline
-%   mode using the LPC order given in NLPC.  The input DATA is a struct
+%   AUDAPTER_RUNFRAMES(DATA,P) runs audio through Audapter's offline
+%   mode using the Audapter parameters provided in P.  The input DATA is a struct
 %   array with fields 'signalIn' and 'params' (i.e., the same format
 %   returned by Audapter).
 
-if nargin < 2, nlpc = 15; end
-
 % set Audapter param fields
-gender = 'female'; % dummy var for getting default params; will be overwritten by nlpc
-p = getAudapterDefaultParams(gender);
+gender = 'female'; % dummy var for getting default params; overwritten by P if provided
+pDefault = getAudapterDefaultParams(gender);
 downFact = 3; % Downsampling factor
 fsNoDS = 48000; % Sampling rate, before downsampling
 frameLenNoDS = 96;  % Frame length before downsampling (# of samples)
-p.downFact = downFact;
-p.sr = fsNoDS / downFact;
-p.frameLen = frameLenNoDS / downFact;
-p.bShift = 0;
-p.nLPC = nlpc;
+pDefault.downFact = downFact;
+pDefault.sr = fsNoDS / downFact;
+pDefault.frameLen = frameLenNoDS / downFact;
+
+%pDefault.bShift = 0;
+%pDefault.nLPC = nlpc;
+
+if nargin < 2 
+    p = pDefault;
+else
+    p = add2struct(pDefault,p);    
+end
+
 
 % Nullify OST and PCF, so that they won't override the perturbation field
 Audapter('ost', '', 0);

--- a/speech/audapter_runWav.m
+++ b/speech/audapter_runWav.m
@@ -8,5 +8,5 @@ if nargin < 2, nlpc = 15; end
 [y,fs] = audioread(wavfile);
 data.signalIn = y;
 data.params.sr = fs;
-
-[dataOut] = audapter_runFrames(data,nlpc);
+p.nlpc = nlpc;
+[dataOut] = audapter_runFrames(data,p);


### PR DESCRIPTION
Changes below to allow for a custom "p" parameter structure for running audapter on an existing signal. A use case I just had for this was needing to provide a different p.pertAmp to generate the noShift/shiftUp/shiftDown stimuli in the port speech perception experiment. I made the same change to check_audapterLPC as I did to audapter_runWav below, these were in a separate commit to current studies though. I'm realizing I messed up the order of operations a bit, as I should have done this first but you should be able to test these changes on check_audapterLPC and then we can do the move of experiment_helpers to free-speech.