### PR TITLE
check_audio saves signalIn and signalOut info

### DIFF
--- a/experiment_helpers/check_audio.m
+++ b/experiment_helpers/check_audio.m
@@ -1,4 +1,4 @@
-function check_audio(dataPath,trialinds,bSort,nTrials,stringType)
+function check_audio(dataPath,trialinds,bSort,nTrials,stringType, buffertype)
 % DATA = CHECK_AUDIO(dataPath,trialinds)
 % Function cycles through trials to check that participant said correct
 % word. Inputs:
@@ -8,12 +8,15 @@ function check_audio(dataPath,trialinds,bSort,nTrials,stringType)
 %   bSort: sort trials by word (1) or don't (0). Default is 0. (currently
 %   not implemented)
 %   nTrials: how many trials to analyze at a time. Default is 10
+%   buffertype: which field to use from data struct. Only tested with
+%     signalIn or signalOut. (default: signalIn)
 
 if nargin < 1 || isempty(dataPath), dataPath = cd; end
 if nargin < 2, trialinds = []; end
 if nargin < 3 || isempty(bSort), bSort = 0; end
 if nargin < 4 || isempty(nTrials), nTrials = 10; end
 if nargin < 5 || isempty(stringType), stringType = 'listWords'; end
+if nargin < 6 || isempty(buffertype), buffertype = 'signalIn'; end
 
 %% create GUI
 f = figure('Visible','off','Units','Normalized','Position',[.1 .1 .8 .8]);
@@ -25,6 +28,7 @@ UserData.f =f;
 UserData.nTrials = nTrials;
 UserData.bSort = bSort;
 UserData.stringType = stringType;
+UserData.buffertype = buffertype;
 
 % load data
 UserData.dataPath = dataPath;
@@ -179,16 +183,16 @@ end
 function playAll(src,evt)
     UserData = guidata(src);
     for i = 1:length(UserData.currTrials)
-        signalIn = UserData.data(UserData.currTrials(i)).signalIn;
+        signal = UserData.data(UserData.currTrials(i)).(UserData.buffertype);
         if isfield(UserData.data(UserData.currTrials(i)).params,'fs')
             fs = UserData.data(UserData.currTrials(i)).params.fs;
         else
             fs = UserData.data(UserData.currTrials(i)).params.sr;
         end
-        soundsc(signalIn,fs)
+        soundsc(signal,fs)
         oldBG = UserData.bg(i).BackgroundColor;
         UserData.bg(i).BackgroundColor = [1 1 0];
-        pause(length(signalIn)./fs + .025)
+        pause(length(signal)./fs + .025)
         UserData.bg(i).BackgroundColor = oldBG;
     end
 end
@@ -270,7 +274,7 @@ function plotTrials(src)
         'Position',[.1 .275 .8 .425],'Box','on','Visible','off');
 
         axes(UserData.haxes(iBg))
-        currSig = UserData.data(UserData.currTrials(iBg)).signalIn;
+        currSig = UserData.data(UserData.currTrials(iBg)).(UserData.buffertype);
         plot(currSig,'k')
         set(UserData.haxes(iBg),'XTick',[],'YTick',[])
         if max(abs(currSig)) < 0.5
@@ -300,17 +304,17 @@ function replayTrial(src,evt)
     UserData = guidata(src);
     trialNumber = str2num(src.Parent.Title);
     tagNumber = str2num(src.Parent.Tag);
-    signalIn = UserData.data(trialNumber).signalIn;
+    signal = UserData.data(trialNumber).(UserData.buffertype);
     if isfield(UserData.data(trialNumber).params,'fs')
         fs = UserData.data(trialNumber).params.fs;
     else
         fs = UserData.data(trialNumber).params.sr;
     end
-    soundsc(signalIn,fs)
+    soundsc(signal,fs)
     
     oldBG = UserData.bg(tagNumber).BackgroundColor;
     UserData.bg(tagNumber).BackgroundColor = [1 1 0];
-    pause(length(signalIn)./fs + .025)
+    pause(length(signal)./fs + .025)
     UserData.bg(tagNumber).BackgroundColor = oldBG;
     UserData.lastTargetTrial = tagNumber;
 end

--- a/experiment_helpers/check_audio.m
+++ b/experiment_helpers/check_audio.m
@@ -153,6 +153,7 @@ function saveData(src,evt)
         save(fullfile(UserData.dataPath,'dataVals_signalOut.mat'),'dataVals'); %save dataVals structure, signalOut
     end
     
+    % make trials and trials_signalOut folders if needed
     for i = 1:length(trialfolder)
         if ~exist(fullfile(UserData.dataPath,trialfolder{i}),'dir')
             mkdir(fullfile(UserData.dataPath,trialfolder{i}))
@@ -276,7 +277,6 @@ function plotTrials(src)
         end
         
         % make axis for signalIn
-        %UserData.haxes(iBg) = axes(UserData.bg(iBg),'Units','Normalized', 'Position',[.1 .275 .8 .425],'Box','on','Visible','off');
         UserData.haxes(iBg) = axes(UserData.bg(iBg),'Units','Normalized',...    
         'Position',[.1 .5 .8 .225],'Box','on','Visible','off');
     
@@ -287,23 +287,30 @@ function plotTrials(src)
         % UserData.haxes(iBg) becomes current axes
         axes(UserData.haxes(iBg))
         currSig = UserData.data(UserData.currTrials(iBg)).signalIn;
+        signalInLength = length(currSig);
         plot(currSig,'k')
+        xlim([0 signalInLength]);
         set(UserData.haxes(iBg),'XTick',[],'YTick',[])
-        if max(abs(currSig)) < 0.5
-            ylim([-.5 .5])
+        if max(abs(currSig)) < 0.4
+            ylim([-.4 .4])
         else
             ylim([-max(abs(currSig)) max(abs(currSig))])
         end
         
-        % repeat process for signalOut, with UserData.haxesOut
+        % repeat process for signalOut, with UserData.haxesOut(iBg)
         axes(UserData.haxesOut(iBg))
-        currSig = UserData.data(UserData.currTrials(iBg)).signalOut;
-        plot(currSig,'k')
-        set(UserData.haxesOut(iBg),'XTick',[],'YTick',[])
-        if max(abs(currSig)) < 0.5
-            ylim([-.5 .5])
-        else
-            ylim([-max(abs(currSig)) max(abs(currSig))])
+        try
+            currSig = UserData.data(UserData.currTrials(iBg)).signalOut;
+            plot(currSig,'k')
+            xlim([0 signalInLength]);
+            set(UserData.haxesOut(iBg),'XTick',[],'YTick',[])
+            if max(abs(currSig)) < 0.4
+                ylim([-.4 .4])
+            else
+                ylim([-max(abs(currSig)) max(abs(currSig))])
+            end
+        catch
+            %leave axis blank
         end
         
         dispID = iBg;


### PR DESCRIPTION
Made a new, 6th input parameter for `check_audio.m` that accepts either 'signalIn' (default) or 'signalOut'. Pretty straightforward. I did some light testing and it worked.

I took the variable name 'buffertype' from `waverunner.m`, where that variable serves the same purpose as here.