### PR TITLE
new fields stimulusText in expt struct

### DIFF
--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -83,6 +83,15 @@ expt = set_missingField(expt,'listColors',expt.colors(expt.allColors));
 expt = set_missingField(expt,'shiftMags',zeros(1,expt.ntrials));
 expt = set_missingField(expt,'shiftAngles',zeros(1,expt.ntrials));
 
+% actual stimulus string shown to participant
+expt = set_missingField(expt,'stimulusText',expt.words);
+expt = set_missingField(expt,'allStimulusText',expt.allWords);
+if all(strcmp(expt.words, expt.stimulusText)) 
+    expt = set_missingField(expt,'listStimulusText',expt.listWords);
+else  %, make list from stimulusText instead of words
+    expt = set_missingField(expt,'listStimulusText',expt.stimulusText(expt.allStimulusText));
+end
+
 %% stimulus timing parameters, in seconds
 timing.stimdur = 1.5;            % time of recording
 timing.visualfbdur = 0.5;      % time visual feedback is shown

--- a/templates/modelExpt/run_modelExpt_audapter.m
+++ b/templates/modelExpt/run_modelExpt_audapter.m
@@ -134,7 +134,7 @@ for itrial = firstTrial:lastTrial
         h_trialn = text(h_sub(1),0,0.5,ctrltxt,'Color','black', 'FontSize',30, 'HorizontalAlignment','center');
 
         % set text
-        txt2display = expt.listWords{itrial};
+        txt2display = expt.listStimulusText{itrial};
         color2display = expt.colorvals{expt.allColors(itrial)};
 
         % set new perturbation

--- a/templates/modelExpt/run_modelExpt_expt.m
+++ b/templates/modelExpt/run_modelExpt_expt.m
@@ -203,7 +203,7 @@ for blockIx = 1:length(expt.conds)
         expt.allWords(itrial) = wordIx(1 + itrial-firstInBlock);
     end
 end
-expt.stimulusList = expt.words;
+expt.stimulusText = expt.words;
 
 %% Set other expt values
 %There are a lot of other parameters you can set that control how the

--- a/templates/modelExpt/run_modelExpt_expt.m
+++ b/templates/modelExpt/run_modelExpt_expt.m
@@ -203,6 +203,7 @@ for blockIx = 1:length(expt.conds)
         expt.allWords(itrial) = wordIx(1 + itrial-firstInBlock);
     end
 end
+expt.stimulusList = expt.words;
 
 %% Set other expt values
 %There are a lot of other parameters you can set that control how the
@@ -246,6 +247,10 @@ end
             expt.ntrials: total number of trials in the experiment
             expt.breakFrequency: the number of trials between breaks
             expt.breakTrials: the trials after which there will be a break
+            expt.stimulusText: What actually displays to participants in a
+                trial
+            expt.allStimulusText: Indexes of stimulusText for each trial
+            expt.listStimulusText: The stimulusText string for each trial
         formant shifting params (for Audapter):
             expt.shiftMags: vector of the magnitude of formant shifts for 
                 each trial


### PR DESCRIPTION
_This is a minor change, so I'll plan on merging EOD Friday unless something comes up._

Problem: New experiments, including vsaSentence and taimComp, have stimuli that are longer than one word and do not fit the same format (cf. timeAdapt, where the stimulus was longer than one word, but all followed the same format: "a capper," "a sapper," etc.). There are various functions that assume each cell array in expt.words is only one word long, meaning expt.words cannot contain the full text that the participant will be reading.

Solution: Add three new default fields to expt, namely `expt.stimulusText`, `expt.allStimulusText`, and `expt.listStimulusText`. expt.stimulusText will contain each of the full phrases participants will be shown, and it has a 1:1 mapping with expt.words. expt.allStimulusText is an index for each trial of which item in expt.stimulusText to display. expt.listStimulusText is a character array for each trial of the literal string that will be displayed.

The model experiment has also been updated to use these new features. Not much has changed: the _audapter function now simply sets `txt2display` based on expt.stimulusText rather than expt.words.

