### PR TITLE
new options for controlling plot_duration_feedback // add bIgnoreVowels

### DIFF
--- a/experiment_helpers/plot_duration_feedback.m
+++ b/experiment_helpers/plot_duration_feedback.m
@@ -1,4 +1,4 @@
-function [h_dur,success,vowel_dur] = plot_duration_feedback(h_fig, data, params)
+function [h_dur,success,vowel_dur] = plot_duration_feedback(h_fig, data, params, ostTrigger)
 %add duration feedback to display for auditory compensation study. Inputs:
 %   h_fig:          figure handle for plot
 %   data:           Audapter data file for a single trial
@@ -13,8 +13,14 @@ function [h_dur,success,vowel_dur] = plot_duration_feedback(h_fig, data, params)
 %                   to look for the first (1) or last (0) frame that drops
 %                   below the offset threshold.
 %      bPrintDuration:  If 1, print vowel_dur for each trial, default 0.
+%      bMeasureOst:     If 1, measure vowel length via duration of ost
+%                       status specified in ostTrigger. Default 0.
+%   ostTrigger:     The ost status used to measure duration. Only used if
+%                   params.bMeasureOst==1. Default [].
 
 if nargin < 3 || isempty(params), params = []; end
+if nargin < 4, ostTrigger = []; end
+
 
 %default duration tracking parameters
 if ~isfield(params,'offs_thresh')
@@ -38,35 +44,50 @@ end
 if ~isfield(params, 'bPrintDuration')
     params.bPrintDuration = 0;
 end
-%get amplitude data from Audapter data structure
-ampl = data.rms(:,1);
-
-%find maximum amplitude
-[max_a,imax] = max(ampl);
-
-%find first point above amplitude threshold
-above_thresh = find(ampl>max_a*params.ons_thresh);
-if ~isempty(above_thresh)
-    onset = above_thresh(1);
-else
-    onset = [];
+if ~isfield(params, 'bMeasureOst')
+    params.bMeasureOst = 0;
 end
 
-if params.bFirst_offs_thresh
-    %find first point after amplitude max below amplitude threshold
-    below_thresh = find(ampl(imax:end)<max_a*params.offs_thresh);
-else
-    % find last point after max that's at or above the amplitude threshold.
-    % Add 1 to find the frame right after.
-    below_thresh = find(ampl(imax:end)>=max_a*params.offs_thresh, 1, 'last') + 1;
-end
 
-if ~isempty(below_thresh)
-    offset = below_thresh(1)+imax;
-else
-    offset = [];
+if params.bMeasureOst  %use OST statuses to find onset and offset
+    onset = find(data.ost_stat == ostTrigger, 1);
+    offset = find(data.ost_stat == ostTrigger+1, 1, 'last');
+    if ~find(data.ost_stat == ostTrigger+2, 1)
+        bOstStuck = 1; %ost didn't advance to the next "full" status
+    else
+        bOstStuck = 0;
+    end
+else  %use general amplitude thresholds to find onset and offset
+    %get amplitude data from Audapter data structure
+    ampl = data.rms(:,1);
+    
+    %find maximum amplitude
+    [max_a,imax] = max(ampl);
+    
+    %find first point above amplitude threshold
+    above_thresh = find(ampl>max_a*params.ons_thresh);
+    if ~isempty(above_thresh)
+        onset = above_thresh(1);
+    else
+        onset = [];
+    end
+    
+    if params.bFirst_offs_thresh
+        %find first point after amplitude max below amplitude threshold
+        below_thresh = find(ampl(imax:end)<max_a*params.offs_thresh);
+    else
+        % find last point after max that's at or above the amplitude threshold.
+        % Add 1 to find the frame right after.
+        below_thresh = find(ampl(imax:end)>=max_a*params.offs_thresh, 1, 'last') + 1;
+    end
+    
+    if ~isempty(below_thresh)
+        offset = below_thresh(1)+imax;
+    else
+        offset = [];
+    end 
 end
-
+    
 %find vowel duration in frames
 if ~isempty(offset) && ~isempty(onset)
     vowel_dur_frames = offset-onset;
@@ -80,7 +101,11 @@ vowel_dur = vowel_dur_frames*data.params.frameLen/data.params.sr;
 center = [params.circ_pos(1)+0.05 params.circ_pos(2)];
 %plot feedback
 figure(h_fig)
-if vowel_dur <= params.max_dur && vowel_dur >= params.min_dur
+if params.bMeasureOst && bOstStuck
+    h_dur(1) = viscircles(center,.05,'Color',[1 0.5 0]); %orange
+    h_dur(2) = text(params.circ_pos(1)+0.05,params.circ_pos(2)-0.1,{'Speak a little clearer'}, 'Color', [1 0.5 0], 'FontSize', 30,'HorizontalAlignment','Center');
+    success = 0;
+elseif vowel_dur <= params.max_dur && vowel_dur >= params.min_dur
     %h_dur(1) = rectangle('Position',params.circ_pos,'Curvature',[1,1],'Facecolor', 'g');
     h_dur(1) = viscircles(center,.05,'Color','g');
     success = 1;

--- a/experiment_helpers/plot_duration_feedback.m
+++ b/experiment_helpers/plot_duration_feedback.m
@@ -1,4 +1,4 @@
-function [h_dur,success] = plot_duration_feedback(h_fig, data, params)
+function [h_dur,success,vowel_dur] = plot_duration_feedback(h_fig, data, params)
 %add duration feedback to display for auditory compensation study. Inputs:
 %   h_fig:          figure handle for plot
 %   data:           Audapter data file for a single trial

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -113,6 +113,7 @@ durcalc.ons_thresh = 0.3;
 durcalc.offs_thresh = 0.4;
 durcalc.bFirst_offs_thresh = 1;
 durcalc.bPrintDuration = 0;
+durcalc.bMeasureOst = 0;
 expt = set_missingField(expt,'durcalc',durcalc);
 
 %% amplitude tracking parameters

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -104,6 +104,8 @@ durcalc.min_dur = .25;         %
 durcalc.max_dur = .5;
 durcalc.ons_thresh = 0.3;
 durcalc.offs_thresh = 0.4;
+durcalc.bFirst_offs_thresh = 1;
+durcalc.bPrintDuration = 0;
 expt = set_missingField(expt,'durcalc',durcalc);
 
 %% amplitude tracking parameters

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -36,7 +36,10 @@ expt = set_missingField(expt,'conds',{'test'});
 expt = set_missingField(expt,'words',{'bed'});
 
 % vowels
-if ~isfield(expt,'vowels')
+expt = set_missingField(expt,'bIgnoreVowels',0);
+if expt.bIgnoreVowels
+    expt.vowels = {'null'};
+elseif ~isfield(expt,'vowels')
     [vowels,~,ivowels] = unique(txt2ipa(expt.words));
     if length(vowels) == length(ivowels), vowels = vowels(ivowels); end
     expt = set_missingField(expt,'vowels',vowels);
@@ -70,7 +73,11 @@ expt = set_missingField(expt,'allColors',randi(length(expt.colors),[1,expt.ntria
 expt = set_missingField(expt,'listConds',expt.conds(expt.allConds));
 expt = set_missingField(expt,'listWords',expt.words(expt.allWords));
 if ~isempty(expt.vowels)
-    expt = set_missingField(expt,'listVowels',txt2ipa(expt.listWords));
+    if expt.bIgnoreVowels
+        expt.listVowels = repmat(expt.vowels, [1 expt.ntrials]);
+    else
+        expt = set_missingField(expt,'listVowels',txt2ipa(expt.listWords));
+    end
     if any(expt.allVowels == 0)
         for t=1:expt.ntrials
             expt.allVowels(t) = find(strcmp(expt.listVowels{t},expt.vowels));

--- a/speech/txt2ipa.m
+++ b/speech/txt2ipa.m
@@ -22,7 +22,6 @@ er = ismember(txtcell,{'er' 'blur' 'bird'});
 oe = ismember(txtcell,{'oe' 'oeuf' 'neuf' 'öde' 'oede' 'böse' 'boese'});
 ou = ismember(txtcell,{'ceux'});
 uh = ismember(txtcell,{'uh' 'good' 'hood'});
-uu = ismember(txtcell,{'uu'});
 xx = ismember(txtcell,{'xx' '*' '**' '***'});
 os = ismember(txtcell,{'os'});
 uu = ismember(txtcell,{'uu'});


### PR DESCRIPTION
This PR adds a few pieces of functionality:
* `plot_duration_feedback` has a switch to make it work better for sentence-length stimuli
* `plot_duration_feedback` can print out the vowel duration and return it as an output argument.
* Experiments not using the `expt.vowels` set of fields can set a new `expt.bIgnoreVowels` flag and don't have to worry about updating `txt2ipa`
* `set_exptDefaults` updated accordingly for the above

In `plot_duration_feedback`, `params.bFirst_offs_thresh` is a switch which controls how the utterance offset threshold is determined. It defaults to `1`, which was the previous behavior. When `1`, the offset is the **first** time the signal intensity reaches `params.offs_thresh`, after it has peaked. This works fine for single-syllable words. Multi-syllable words and sentences will have drops in intensity which shouldn't trigger the end of the utterance. Thus, when `params.bFirst_offs_thresh` is `0`, the offset is the **last** time the signal intensity drops below `params.offs_thresh` -- i.e., after the offset, the signal stays below `params.offs_thresh`.

The second change creates `params.bPrintDuration` as a value in `plot_duration_feedback`. When set to `1` (default is `0`), the experiment will print a message saying what the utterance duration was for that trial. This is useful when troubleshooting or determining onset and offset thresholds for a new experiment. `vowel_dur` is now the third output parameter for experiments which wish to track that.

Thirdly, experiments which do not utilize or differentiate based on vowel can now set `expt.bIgnoreVowels` to `1` before running `set_exptDefaults` and not have to worry about anything else. This will result in `expt.vowels = {'null'};`, `expt.allVowels` will be `1` for each trial, and `expt.listTrials` will be `{null}` for each trial. The functions `gen_fdata` and `calc_fdata` were checked to make sure this wouldn't break anything.

An error in `txt2ipa` was removed, where there were two instances of `uu` being defined.