### PR TITLE
Do not attempt to plot into a sub plot axes object if it does not exist

### DIFF
--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -9,7 +9,7 @@ else
     bGoodTrial = 0;
 end
 
-if subAxis
+if isgraphics(subAxis)
     subplot(subAxis)
     tAxis = 0 : data.params.frameLen : data.params.frameLen * (size(data.fmts, 1) - 1);
     yyaxis left

--- a/speech/audioGUI.m
+++ b/speech/audioGUI.m
@@ -47,8 +47,15 @@ end
 
 % loop through trials
 for itrial = trials2track
+    
     %% prepare inputs
     y = data(itrial).(buffertype);
+    
+    %Skip trials where signalIn is empty
+    if isempty(y)
+        fprintf('Trial %d has an empty SignalIn field, Skipping for now.', itrial)
+        continue;
+    end  
     
     if isfield([data.params],'fs')
         fs = data(itrial).params.fs;


### PR DESCRIPTION
Carrie made some changes a while back to skip plotting the RMS threshold subplot for experiments on the iEEG cart PC (no second monitor). Handling this case instead of erroring seems like a reasonable thing to do in the context of any experiment. 