### PR TITLE
Conditional to skip a trial if it's signalIn is empty in data

### DIFF
--- a/speech/audioGUI.m
+++ b/speech/audioGUI.m
@@ -47,8 +47,15 @@ end
 
 % loop through trials
 for itrial = trials2track
+    
     %% prepare inputs
     y = data(itrial).(buffertype);
+    
+    %Skip trials where signalIn is empty
+    if isempty(y)
+        fprintf('Trial %d has an empty SignalIn field, Skipping for now.', itrial)
+        continue;
+    end  
     
     if isfield([data.params],'fs')
         fs = data(itrial).params.fs;


### PR DESCRIPTION
Some simple code to inform someone who is tracking data that one of the trials they provided does not have data to display, and to skip to loading the next trial. This is useful in the context of experiments like mriSIS/iEEGSIS because there are "Listen" trials. We were previously just excluding them from data altogether, but this causes undesirable downstream effects in generating trial files with correct names (contents of the "trials" folder after tracking) and subsequently with the token field in dataVals. 