### PR TITLE
Wrapper function for get_gender, changes question to set expt.gender

### DIFF
--- a/experiment_helpers/get_height.m
+++ b/experiment_helpers/get_height.m
@@ -1,0 +1,22 @@
+function gender = get_height(heightResponse)
+%get_gender -> get_height
+%VTL increases with height over a large range of heights, 
+%good to not put assuming a participants gender on individual running the experiment. 
+
+if nargin < 1, heightResponse = []; end
+
+if ~any(strcmp(heightResponse,{'y','n'}))
+    heightResponse = input("Does the participant appear to be above the height 5' 8''? (y/n): ", 's');
+    while ~any(strcmp(heightResponse,{'y','n'}))
+        heightResponse = input('Invalid response. Please enter y/n: ','s');
+    end
+    
+    if strcmp(heightResponse, 'y')
+        gender = get_gender('male');
+    elseif strcmp(heightResponse, 'n')
+        gender = get_gender('female');
+    end
+    
+end
+
+end

--- a/experiment_helpers/get_height.m
+++ b/experiment_helpers/get_height.m
@@ -6,7 +6,7 @@ function gender = get_height(heightResponse)
 if nargin < 1, heightResponse = []; end
 
 if ~any(strcmp(heightResponse,{'y','n'}))
-    heightResponse = input("Does the participant appear to be above the height 5' 8''? (y/n): ", 's');
+    heightResponse = input("Does the participant appear to be above the height 5' 8""? (y/n): ", 's');
     while ~any(strcmp(heightResponse,{'y','n'}))
         heightResponse = input('Invalid response. Please enter y/n: ','s');
     end

--- a/templates/modelExpt/run_modelExpt_expt.m
+++ b/templates/modelExpt/run_modelExpt_expt.m
@@ -86,7 +86,7 @@ if isfile(fullfile(expt.dataPath, 'expt.mat'))
 end
 
 % other expt.mat setup
-if ~isfield(expt,'gender'), expt.gender = get_gender; end
+if ~isfield(expt,'gender'), expt.gender = get_height; end
 expt.words = {'bed', 'dead', 'head'};
 
 


### PR DESCRIPTION
Want to change the question the experimenter is asked while setting up expt from the biological sex of the participant to their height, as VTL strongly correlates with body height. 

Corresponding change to new run_EXPTNAME_expt scripts:
``if ~isfield(expt,'gender'), expt.gender = get_height; end``