### PR TITLE
Fix typo re: ostInds

### DIFF
--- a/experiment_helpers/calc_vowelMeans.m
+++ b/experiment_helpers/calc_vowelMeans.m
@@ -3,7 +3,7 @@ function [fmtMeans, fmtStds] = calc_vowelMeans(dataPath,conds2analyze,bRmOutlier
 %   FMTMEANS = CALC_VOWELMEANS(DATAPATH) calculates mean formants for each
 %   vowel in an Audapter experiment. DATAPATH is the path to a folder
 %   containing data.mat (Audapter output data) and expt.mat (experiment
-%   metadata) files. OSTIND is the desired OST status to track.
+%   metadata) files. OSTINDS is the desired OST status to track.
 
 if nargin < 1 || isempty(dataPath), dataPath = pwd; end
 load(fullfile(dataPath,'expt.mat'),'expt');

--- a/experiment_helpers/calc_vowelMeans.m
+++ b/experiment_helpers/calc_vowelMeans.m
@@ -1,4 +1,4 @@
-function [fmtMeans, fmtStds] = calc_vowelMeans(dataPath,conds2analyze,bRmOutliers,ostInd,bTest)
+function [fmtMeans, fmtStds] = calc_vowelMeans(dataPath,conds2analyze,bRmOutliers,ostInds,bTest)
 %CALC_VOWELMEANS  Calculates mean vowel formants from Audapter OST data.
 %   FMTMEANS = CALC_VOWELMEANS(DATAPATH) calculates mean formants for each
 %   vowel in an Audapter experiment. DATAPATH is the path to a folder
@@ -10,7 +10,7 @@ load(fullfile(dataPath,'expt.mat'),'expt');
 load(fullfile(dataPath,'data.mat'),'data');
 if nargin < 2 || isempty(conds2analyze), conds2analyze = expt.conds; end
 if nargin < 3 || isempty(bRmOutliers), bRmOutliers = 1; end
-if nargin < 4 || isempty(ostInd), ostInds = 2; end
+if nargin < 4 || isempty(ostInds), ostInds = 2; end
 if nargin < 5 || isempty (bTest), bTest = 0;end
 
 %load data


### PR DESCRIPTION
Just double-checking this fix -- currently this will break if you try to set ostInd as an argument (the variable ostInds only gets set if ostInd is empty).