### PR TITLE
add switch for ost_stat and ost_calc in calc_vowelMeans

### DIFF
--- a/experiment_helpers/calc_vowelMeans.m
+++ b/experiment_helpers/calc_vowelMeans.m
@@ -39,7 +39,11 @@ framedur = 1 / data(1).params.sr*data(1).params.frameLen; %get frame duration
 offset = [floor(0.05 / framedur) floor(0.01 / framedur)]; %account for hold time in ost tracking
 if bTest;figure;end
 for itrial = trials2analyze
-    ost = data(itrial).ost_stat;
+    if isfield(data, 'ost_calc')
+        ost = data(itrial).ost_calc; %user-configured values
+    else
+        ost = data(itrial).ost_stat; %values from initial settings
+    end
     if bdataVals
         F1s(itrial) = nanmedian(midnperc(dataVals(itrial).f1,50));
         F2s(itrial) = nanmedian(midnperc(dataVals(itrial).f2,50));

--- a/experiment_helpers/calc_vowelMeans.m
+++ b/experiment_helpers/calc_vowelMeans.m
@@ -39,7 +39,7 @@ framedur = 1 / data(1).params.sr*data(1).params.frameLen; %get frame duration
 offset = [floor(0.05 / framedur) floor(0.01 / framedur)]; %account for hold time in ost tracking
 if bTest;figure;end
 for itrial = trials2analyze
-    if isfield(data, 'ost_calc')
+    if isfield(data, 'ost_calc') && ~isempty(data(itrial).ost_calc)
         ost = data(itrial).ost_calc; %user-configured values
     else
         ost = data(itrial).ost_stat; %values from initial settings


### PR DESCRIPTION
Added a switch in `calc_vowelMeans` which will use data.ost_calc (i.e., user-specified OST values) if it's available. If that field doesn't exist or is empty for that trial, the function will use the old method of data.ost_stat (i.e., the original output OST values), which will always exist and be non-empty.