### PR TITLE
Use the correct 'experiments' folder path on the iEEG Cart PC.

### DIFF
--- a/utils/get_exptLocalPath.m
+++ b/utils/get_exptLocalPath.m
@@ -1,12 +1,28 @@
 function [exptPath] = get_exptLocalPath(exptName,varargin)
+%GET_EXPTLOCALPATH Return path to experiment folder on the local machine
+%   GET_EXPTLOCALPATH(EXPTNAME,VARARGIN)
+%       Returns the path to an experiment's (specified with EXPTNAME 
+%       argument) local directory in the shared/public documents folder. If
+%       no EXPTNAME is provided, returns the path to the computers
+%       'experiments' folder. Can use VARARGIN to specify subfolders. 
+%
+%       Currently accounts for Mac vs PC distinction, and Lab PC vs iEEG
+%       Cart PC.
 
 if nargin < 1, exptName = []; end
 
 if ispc
-    basePath = 'C:\Users\Public\Documents\experiments\';    
+        %Handle iEEG cart machine 
+        if strcmp(getenv('COMPUTERNAME'), 'DESKTOP-JM96JC7') %Saalmann Lab PC
+            basePath = get_exptSavePathIEEG;
+        else
+            basePath = 'C:\Users\Public\Documents\experiments\';
+        end
+        
 elseif ismac
     basePath = '/Users/Shared/Documents/experiments';
 elseif isunix
     error('Unix not supported currently!')
 end
+
 exptPath = fullfile(basePath,exptName,varargin{:});


### PR DESCRIPTION
Added a nested conditional to the ispc section of this code to check if the COMPUTERNAME environment variable of the computer it is called on matches that of the iEEG Cart PC, sets the experiment folder path accordingly. Grabbed the PC name from the last data collection's expt structure, would be great to sanity check this on the cart PC itself. Also updated helpdocs for this function.