### PR TITLE
Include current time (HH:MM:SS) as item stored in expt structure, get_gender->get_height

### DIFF
--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -15,7 +15,7 @@ else                         % otherwise validate snum
     expt.snum = get_snum(expt.snum);
 end
 if ~isfield(expt,'gender')   % prompt for gender if not defined
-    expt.gender = get_gender;
+    expt.gender = get_height;
 else                         % otherwise validate gender
     expt.gender = get_gender(expt.gender);
 end
@@ -24,7 +24,8 @@ if ~isfield(expt,'dataPath') % prompt for dataPath if not defined
 end
 
 %% environment parameters
-expt = set_missingField(expt,'date',date);    %sets date to current date if not defined
+expt = set_missingField(expt,'date',datetime);    %sets date to current date if not defined
+expt = set_missingField(expt,'time',datestr(now,'HH:MM:SS')); %set time to current time
 expt = set_missingField(expt,'compName',getenv('COMPUTERNAME'));  %gets name of computer
 expt = set_missingField(expt,'username',getenv('username'));  %gets current username (whoever is logged in while running experiment)
     

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -24,7 +24,7 @@ if ~isfield(expt,'dataPath') % prompt for dataPath if not defined
 end
 
 %% environment parameters
-expt = set_missingField(expt,'date',datetime);    %sets date to current date if not defined
+expt = set_missingField(expt,'date',date);    %sets date to current date if not defined
 expt = set_missingField(expt,'time',datestr(now,'HH:MM:SS')); %set time to current time
 expt = set_missingField(expt,'compName',getenv('COMPUTERNAME'));  %gets name of computer
 expt = set_missingField(expt,'username',getenv('username'));  %gets current username (whoever is logged in while running experiment)


### PR DESCRIPTION
I can't remember if this was talked about when we initially added date to the default expt file, but the situation with the trial number mismatch in the iEEG data collection have me thinking that it might be a good idea hold on to time of expt creation  alongside date. I realize that 'time' could be a confusing field name alongside 'timing', so we could just do something like setting date to `datetime('now')` instead. Also made a quick swap of get_gender to get_height as default behavior for asking for participant gender.