### PR TITLE
Fix issue where number of perturbation trials is 1

### DIFF
--- a/experiment_helpers/randomize_stimuli.m
+++ b/experiment_helpers/randomize_stimuli.m
@@ -136,7 +136,7 @@ for iblock = 1:expt.nblocks
     nonpertLeftover = nonpertTrials(length(pertTrials)+1:expt.ntrials_per_block - length(pertTrials));
     
     % randomly-ordered vector of 0's for pertPair and 1's for nonpertLeftover
-    ix = [zeros(1, length(pertPair)), ones(1, length(nonpertLeftover))];
+    ix = [zeros(1, size(pertPair,2)), ones(1, length(nonpertLeftover))];
     ix = ix(randperm(length(ix)));
     
     pertIx = 1;


### PR DESCRIPTION
I was able to find that when setting up a randomly ordered vector of 0s and 1s, the script was using length(pertPair) instead of size(pertPair,2). This returns the length of pertPair (2 when a matrix, indicating 2 pairs. **Also** 2 when a vector containing just 1 pair, but the vector's length is 2) and causes an index out of bounds error. Size of the 2nd dimension should always return the correct number of pairs. 