### PR TITLE
single exptSavePath function, conditionally handling edge cases instead of those being separate scripts

### DIFF
--- a/experiment_helpers/get_exptSavePath_mac.m
+++ b/experiment_helpers/get_exptSavePath_mac.m
@@ -1,6 +1,0 @@
-function [exptPath] = get_exptSavePath(exptName,varargin)
-
-if nargin < 1, exptName = []; end
-
-basePath = 'C:\Users\Public\Documents\experiments\';
-exptPath = fullfile(basePath,exptName,varargin{:});

--- a/utils/get_exptSavePath.m
+++ b/utils/get_exptSavePath.m
@@ -1,6 +1,44 @@
 function [exptPath] = get_exptSavePath(exptName,varargin)
+%GET_EXPTSAVEPATH Return path to experiment folder on the local machine
+%   GET_EXPTSAVEPATH(EXPTNAME,VARARGIN)
+%       Returns the path to an experiment's (specified with EXPTNAME 
+%       argument) local directory in the shared/public documents folder. If
+%       no EXPTNAME is provided, returns the path to the computers
+%       'experiments' folder. Can use VARARGIN to specify subfolders. 
+%
+%       Currently accounts for Mac vs PC distinction, and Lab PC / iEEG
+%       Cart PC / Waisman MRI room PC.
 
 if nargin < 1, exptName = []; end
 
-basePath = 'C:\Users\Public\Documents\experiments\';
+if ispc
+    
+    switch getenv('COMPUTERNAME')
+        
+        %These will need to change in the future if these PC names change. 
+        case 'DESKTOP-JM96JC7' %Saalmann Cart PC name
+            basePath = 'C:\Users\Saalmann Lab\Documents\experiments\Niziolek\experiments';
+        
+        case 'CAFFEINE' %MRI Room Experiment Running PC name
+            basePath = 'C:\My Experiments\';
+        
+        otherwise % Assume lab PC
+            basePath = 'C:\Users\Public\Documents\experiments\';
+     
+    end
+        
+elseif ismac
+    
+    basePath = '/Users/Shared/Documents/experiments';
+
+elseif isunix
+    
+    error('Unix not supported currently!')
+
+end
+
+%Construct the experiment path with the basepath, experiment name, and
+%other arguments. This will be returned by the function. 
 exptPath = fullfile(basePath,exptName,varargin{:});
+
+end


### PR DESCRIPTION
Add switch statement for handling iEEG/MRI PCs to exptSavePath, remove get_exptSavePath_mac (unused by any Lab Repo code).

This pull request will need to be merged at the same time as the pull request of the same name in current-studies to not break anything. 

We should also consider that this function and the acoustSavePath function that accompany it (used in many different experiments) and get_exptLocalPath/get_acoustLocalPath/get_acoustLocalPaths (used in attentioncomp, some plotting functions, and most importantly the modelExpt function that new experiments might draw on as a template) are very similar in their functionality. I think it would be best to have the exptSavePath and acoustSavePath functions subbed in where localPath functions are being used to keep everything consistent. 

Also, there could be confusion with get_exptPath existing, but that is only used in one or two instances and returns a path to Carries local user documents. 