### PR TITLE
Use savePath in modelExpt

### DIFF
--- a/templates/modelExpt/run_modelExpt_expt.m
+++ b/templates/modelExpt/run_modelExpt_expt.m
@@ -72,10 +72,10 @@ expt.name = 'modelExpt';
 expt.trackingFileLoc = 'experiment_helpers'; % Where the OST/PCF files are kept (for audapter_viewer)
 expt.trackingFileName = 'measureFormants'; % What the files are called
 if ~isfield(expt,'snum'), expt.snum = get_snum; end     %eg, sp247
-expt.dataPath = get_acoustLocalPath(expt.name, expt.snum);
+expt.dataPath = get_acoustSavePath(expt.name, expt.snum);
     %CONV Your expt file should be saved to:
     % 'C:\Users\Public\Documents\experiments\[expt.name]\acousticdata\[expt.snum]\'.
-    % `get_acoustLocalPath` will return that, given the input arguments.
+    % `get_acoustSavePath` will return that, given the input arguments.
 
 % Load in existing expt.mat, if there is one
 if isfile(fullfile(expt.dataPath, 'expt.mat'))

--- a/utils/get_acoustLocalPath.m
+++ b/utils/get_acoustLocalPath.m
@@ -1,5 +1,23 @@
 function [dataPath] = get_acoustLocalPath(exptName,sid,varargin)
 %GET_ACOUSTLOCALPATH  Get acoustic local path for given experiment/subject.
+%   GET_ACOUSTLOCALPATH(EXPTNAME,SID,VARARGIN)
+%       Wrapper for the get_exptLocalPath function that returns the path 
+%       to the local machine's acousticdata folder for an
+%       experiment EXPTNAME. Can specify a speaker number SID and 
+%       subfolders with VARARGIN.
+%       
+%       ARGUMENTS:
+%           EXPTNAME - character array containing name of experiment
+%           SID - speaker number, either as 'sp###' or just the number
+%           VARARGIN - one or more extra character array arguments to be
+%           added to the path, used to specify subfolders of the experiment
+%           folder.
+%           
+%       OUTPUT:
+%           EXPTPATH - full path as joined together via fullfile()
+%
+%       NOTE: If you are setting up an experiment running script for the
+%       lab, you should probably be using get_acoustSavePath.m instead.
 
 if nargin < 2 || isempty(sid) % need 'isempty' here because '[]' is numeric
     sid = [];

--- a/utils/get_acoustSavePath.m
+++ b/utils/get_acoustSavePath.m
@@ -1,5 +1,20 @@
 function [dataPath] = get_acoustSavePath(exptName,sid,varargin)
-%GET_ACOUSTSAVEPATH  Get acoustic save path for given experiment/subject.
+%GET_ACOUSTSAVEPATH  Get acoustic local path for given experiment/subject.
+%   GET_ACOUSTSAVEPATH(EXPTNAME,SID,VARARGIN)
+%       Wrapper for the get_exptSavePath function that returns the path 
+%       to the local machine's acousticdata folder for an
+%       experiment EXPTNAME. Can specify a speaker number SID and 
+%       subfolders with VARARGIN.
+%       
+%       ARGUMENTS:
+%           EXPTNAME - character array containing name of experiment
+%           SID - speaker number, either as 'sp###' or just the number
+%           VARARGIN - one or more extra character array arguments to be
+%           added to the path, used to specify subfolders of the experiment
+%           folder.
+%           
+%       OUTPUT:
+%           EXPTPATH - full path as joined together via fullfile()
 
 if nargin < 2 || isempty(sid) % need 'isempty' here because '[]' is numeric
     sid = [];

--- a/utils/get_exptLocalPath.m
+++ b/utils/get_exptLocalPath.m
@@ -1,4 +1,21 @@
 function [exptPath] = get_exptLocalPath(exptName,varargin)
+%GET_EXPTLOCALPATH Return path to experiment folder
+%   GET_EXPTLOCALPATH(EXPTNAME,VARARGIN)
+%       Return the path to the local machine's Documents/experiments
+%       folder, appending the provided EXPTNAME and any additional 
+%       subfolders specified by VARARGIN.
+%       
+%       ARGUMENTS:
+%           EXPTNAME - character array containing name of experiment
+%           VARARGIN - one or more extra character array arguments to be
+%           added to the path, used to specify subfolders of the experiment
+%           folder.
+%           
+%       OUTPUT:
+%           EXPTPATH - full path as joined together via fullfile()
+%
+%       NOTE: If you are setting up an experiment running script for the
+%       lab, you should probably be using get_exptSavePath.m instead.
 
 if nargin < 1, exptName = []; end
 

--- a/utils/get_exptSavePath.m
+++ b/utils/get_exptSavePath.m
@@ -5,6 +5,15 @@ function [exptPath] = get_exptSavePath(exptName,varargin)
 %       argument) local directory in the shared/public documents folder. If
 %       no EXPTNAME is provided, returns the path to the computers
 %       'experiments' folder. Can use VARARGIN to specify subfolders. 
+%       
+%       ARGUMENTS:
+%           EXPTNAME - character array containing name of experiment
+%           VARARGIN - one or more extra character array arguments to be
+%           added to the path, used to specify subfolders of the experiment
+%           folder.
+%           
+%       OUTPUT:
+%           EXPTPATH - full path as joined together via fullfile()
 %
 %       Currently accounts for Mac vs PC distinction, and Lab PC / iEEG
 %       Cart PC / Waisman MRI room PC.


### PR DESCRIPTION
use savePath function in modelExpt instead of localPath so people know which one to use in future scripts built from the template. Also update helpdocs for localPath and savePath functions.