### PR TITLE
Mandarin pause

### DIFF
--- a/experiment_helpers/pause_trial.m
+++ b/experiment_helpers/pause_trial.m
@@ -1,10 +1,16 @@
-function [] = pause_trial(h_fig)
+function [] = pause_trial(h_fig,params)
 
 get_figinds_audapter;
 
 % text params
-pausetxt = 'Paused. Press the space bar to continue.';
-conttxt = 'We will now continue.';
+% Addition for simonToneLex RK 2022-01-31
+if nargin < 2 || isempty(params)
+    pausetxt = 'Paused. Press the space bar to continue.';
+    conttxt = 'We will now continue.';
+else
+    pausetxt = params.pausetxt; 
+    conttxt = params.conttxt; 
+end
 txtparams.Color = 'white';
 txtparams.FontSize = 60;
 txtparams.HorizontalAlignment = 'center';
@@ -27,9 +33,10 @@ catch
 end
 
 delete(h_text)
+pause(1); 
 h_text = text(.5,.5,conttxt,txtparams); % display continue text
-try CloneFig(h_fig(stim),h_fig(dup)); catch; end
-pause(1)
+try CloneFig(h_fig(stim),h_fig(dup)); catch; fprintf('I''m in the catch for cloning'); end
+pause(2)
 delete(h_text)                          % clear continue text
 try CloneFig(h_fig(stim),h_fig(dup)); catch; end
 pause(1)

--- a/experiment_helpers/pause_trial.m
+++ b/experiment_helpers/pause_trial.m
@@ -33,10 +33,9 @@ catch
 end
 
 delete(h_text)
-pause(1); 
 h_text = text(.5,.5,conttxt,txtparams); % display continue text
-try CloneFig(h_fig(stim),h_fig(dup)); catch; fprintf('I''m in the catch for cloning'); end
-pause(2)
+try CloneFig(h_fig(stim),h_fig(dup)); catch; end
+pause(1)
 delete(h_text)                          % clear continue text
 try CloneFig(h_fig(stim),h_fig(dup)); catch; end
 pause(1)

--- a/experiment_helpers/pause_trial.m
+++ b/experiment_helpers/pause_trial.m
@@ -5,12 +5,13 @@ get_figinds_audapter;
 % text params
 % Addition for simonToneLex RK 2022-01-31
 if nargin < 2 || isempty(params)
-    pausetxt = 'Paused. Press the space bar to continue.';
-    conttxt = 'We will now continue.';
-else
-    pausetxt = params.pausetxt; 
-    conttxt = params.conttxt; 
+    params = struct; 
 end
+params = set_missingField(params, 'pausetxt', 'Paused. Press the space bar to continue.', 1); 
+params = set_missingField(params, 'conttxt', 'We will now continue.', 1); 
+pausetxt = params.pausetxt; 
+conttxt = params.conttxt; 
+
 txtparams.Color = 'white';
 txtparams.FontSize = 60;
 txtparams.HorizontalAlignment = 'center';


### PR DESCRIPTION
change to pause_trial to take in optional second argument, params, with assumed structure

params.pausetxt
params.conttxt

To be used for variables paustxt and conttxt, respectively. If empty or no second argument provided, defaults to original paustxt and conttxt. Change made to accommodate Mandarin-language pause and continue texts for simonToneLex. Runs properly with adaptRetest and simonToneLex. 