### PR TITLE
call get_gitPath with new input arg structure

### DIFF
--- a/experiment_helpers/audapter_testcases.m
+++ b/experiment_helpers/audapter_testcases.m
@@ -51,7 +51,7 @@ fprintf('\nAudapter mex file accessed successfully. \n\n');
 
 
 % These test cases use a pre-recorded audio sample
-filename = fullfile(get_gitPath, 'free-speech', 'experiment_helpers', 'audapter_testcases_audio.mat');
+filename = fullfile(get_gitPath('free-speech'), 'experiment_helpers', 'audapter_testcases_audio.mat');
 load(filename, 'signalIn'); % this file's native sampling rate is 48000
 
 % convert audio file to "frame"-length chunks for use in Audapter

--- a/experiment_helpers/check_segmentDuration.m
+++ b/experiment_helpers/check_segmentDuration.m
@@ -94,7 +94,7 @@ if strcmp(trackingFileDir, 'experiment_helpers')
 else
     leadingDir = 'current-studies'; 
 end
-ostWorking = fullfile(get_gitPath, leadingDir, trackingFileDir, [trackingFileName 'Working.ost']); 
+ostWorking = fullfile(get_gitPath(leadingDir), trackingFileDir, [trackingFileName 'Working.ost']); 
 if exist(ostWorking,'file') ~= 2
     refreshWorkingCopy(trackingFileDir, trackingFileName, 'ost');
 end

--- a/experiment_helpers/check_segmentDuration_timeAdapt.m
+++ b/experiment_helpers/check_segmentDuration_timeAdapt.m
@@ -69,7 +69,7 @@ ostFactor = fs/frameLength;
 
 %% Set up OST recognition 
 % Get the buffer amount for the ostStatBegin (so hand correction is more intuitive) 
-ostWorking = fullfile(get_gitPath, 'current-studies', expt.trackingFileLoc, [expt.trackingFileName 'Working.ost']); 
+ostWorking = fullfile(get_gitPath('current-studies'), expt.trackingFileLoc, [expt.trackingFileName 'Working.ost']); 
 ostStatBeginPrev = startStatus - 2; % this is currently true for all cases
 ostStatEndPrev = endStatus - 2; 
 

--- a/experiment_helpers/get_experiment_function.m
+++ b/experiment_helpers/get_experiment_function.m
@@ -52,6 +52,12 @@ switch expName
         expFun = @run_simonSyllableTransfer_audapter;
     case 'noGoAdapt'
         expFun = @run_noGoAdapt_audapter;
+    case 'simonHomophonePic'
+        expFun = @run_simonHomophonePic_audapter;
+    case 'simonHomophoneWord'
+        expFun = @run_simonHomophoneWord_audapter;
+    case 'simonHomophone'
+        expFun = @run_simonHomophone_audapter;
     otherwise
         fprintf('Function for experiment ''%s'' not found.',expName)
         expFun = [];

--- a/experiment_helpers/get_gitPath.m
+++ b/experiment_helpers/get_gitPath.m
@@ -3,11 +3,12 @@ function [repoPath] = get_gitPath(reponame)
 
 if nargin < 1, reponame = 'free-speech'; end
 
+% find path to repo via one of its functions
 switch reponame
     case 'free-speech'
-        mfilename = 'get_gitPath.m';
+        mfilename = 'get_gitPath.m'; % representative function from free-speech
     case 'current-studies'
-        mfilename = 'forcedAlignment.m';
+        mfilename = 'forcedAlignment.m'; % representative function from current-studies
     otherwise
         error('Unknown git repo "%s". Expected "free-speech" or "current-studies".',reponame)
 end

--- a/experiment_helpers/get_gitPath.m
+++ b/experiment_helpers/get_gitPath.m
@@ -1,29 +1,32 @@
-function [gitpath] = get_gitPath
-% INSTRUCTIONS: If you need to change this, copy this file outside of a git
-% repo, save locally, and add the copy to the top of your MATLAB path. You
-% can then remove all of the code, except for one line which hard-codes to
-% the proper filepath.
+function [repoPath] = get_gitPath(reponame)
+% Returns the filepath to the head folder of the input arg's repository.
 
-% gitpath = 'C:\Users\Public\Documents\software'; OLD METHOD
-fileloc = which('get_gitPath.m', '-all');
+if nargin < 1, reponame = 'free-speech'; end
+
+switch reponame
+    case 'free-speech'
+        mfilename = 'get_gitPath.m';
+    case 'current-studies'
+        mfilename = 'forcedAlignment.m';
+    otherwise
+        error('Unknown git repo "%s". Expected "free-speech" or "current-studies".',reponame)
+end
+
+fileloc = which(mfilename, '-all');
 
 if isempty(fileloc)
-    error(['Couldn''t find a file named get_gitPath when searching the MATLAB path. ' ...
-        'Ensure free-speech\experiment_helpers\get_gitPath is on your MATLAB path.']);
+    error('Couldn''t find a file named %s. Ensure the %s repo is on your MATLAB path.',mfilename,reponame);
 end
 
 if length(fileloc) > 1
-    warning(['You have more than one file called get_gitPath in your MATLAB path. ' ...
-        'Using top-listed filepath. Ensure this is the correct one to use.'])
-    which get_gitPath.m -all
+    warning(['You have more than one file called %s in your MATLAB path. ' ...
+        'Using top-listed filepath. Ensure this is the correct one to use.'],mfilename)
+    which(mfilename, '-all')
 end
 
-% Go 3 levels up from get_gitPath to reach the folder containing free-speech
 path_parts = strsplit(fileloc{1}, filesep);
-repo_ix = find(strcmp(path_parts, 'free-speech'));
+repo_ix = find(strcmp(path_parts, reponame));
 
-gitpath = strjoin(path_parts(1:repo_ix - 1), filesep);
-
-
+repoPath = strjoin(path_parts(1:repo_ix), filesep);
 
 end

--- a/experiment_helpers/get_ost.m
+++ b/experiment_helpers/get_ost.m
@@ -58,15 +58,15 @@ if isnumeric(eventNum); eventNum = num2str(eventNum); end
 %% Grab necessary info from OST file
 
 if strcmp(audFileDir, 'experiment_helpers') || strcmp(audFileName, 'measureFormants')
-    trackingPath = fullfile(get_gitPath, 'free-speech', 'experiment_helpers'); 
+    trackingPath = fullfile(get_gitPath('free-speech'), 'experiment_helpers'); 
 elseif isfolder(audFileDir)
     if contains(audFileDir,'/') || contains(audFileDir,'\')
         trackingPath = audFileDir;
     else
-        trackingPath = fullfile(get_gitPath, 'current-studies', audFileDir);
+        trackingPath = fullfile(get_gitPath('current-studies'), audFileDir);
     end
 else
-    trackingPath = fullfile(get_gitPath, 'current-studies', audFileDir); 
+    trackingPath = fullfile(get_gitPath('current-studies'), audFileDir); 
 end
 
 switch masterWorking

--- a/experiment_helpers/get_pcf.m
+++ b/experiment_helpers/get_pcf.m
@@ -82,15 +82,15 @@ end
 %% File and editing information
 
 if strcmp(audFileName, 'measureFormants') || strcmp(audFileDir, 'experiment_helpers') % So theoretically you could be doing some OTHER PCF file that is in experiment_helpers
-    exptDir = fullfile(get_gitPath, 'free-speech', audFileDir); % could potentially hard-code this to experiment_helpers but... 
+    exptDir = fullfile(get_gitPath('free-speech'), audFileDir); % could potentially hard-code this to experiment_helpers but... 
 elseif isfolder(audFileDir)
     if contains(audFileDir,'/') || contains(audFileDir,'\')
         exptDir = audFileDir;
     else
-        exptDir = fullfile(get_gitPath, 'current-studies', audFileDir);
+        exptDir = fullfile(get_gitPath('current-studies'), audFileDir);
     end
 else
-    exptDir = fullfile(get_gitPath, 'current-studies', audFileDir); % ['C:\Users\Public\Documents\software\current-studies\' audFileLoc]; 
+    exptDir = fullfile(get_gitPath('current-studies'), audFileDir); % ['C:\Users\Public\Documents\software\current-studies\' audFileLoc]; 
 end
 
 pcfName = [audFileName 'Working.pcf']; 

--- a/experiment_helpers/refreshWorkingCopy.m
+++ b/experiment_helpers/refreshWorkingCopy.m
@@ -31,10 +31,10 @@ if isfolder(audFileLoc)
     if contains(audFileLoc,'/') || contains(audFileLoc,'\')
         audFilePath = audFileLoc;
     else
-        audFilePath = fullfile(get_gitPath, 'current-studies', audFileLoc);
+        audFilePath = fullfile(get_gitPath('current-studies'), audFileLoc);
     end
 else
-    audFilePath = fullfile(get_gitPath, 'current-studies', audFileLoc);
+    audFilePath = fullfile(get_gitPath('current-studies'), audFileLoc);
 end
     
 try  %current-studies repo
@@ -47,7 +47,7 @@ try  %current-studies repo
     end
 catch 
     try %try free-speech repo
-        audFilePath = fullfile(get_gitPath, 'free-speech', audFileLoc);
+        audFilePath = fullfile(get_gitPath('free-speech'), audFileLoc);
 
         if strcmp(files2refresh,'ost') || strcmp(files2refresh,'both')
             copyfile(fullfile(audFilePath, [audFileName 'Master.ost']), fullfile(audFilePath, [audFileName 'Working.ost']));
@@ -65,7 +65,7 @@ catch
             extension = sprintf('ost or %sMaster.pcf', audFileName);
         end
         error(sprintf('Could not find a file called %sMaster.%s in either %s or %s. Make sure such a file exists.', ...
-            audFileName, extension, fullfile(get_gitPath, 'current-studies', audFileLoc), fullfile(get_gitPath, 'free-speech', audFileLoc))) %#ok<SPERR> 
+            audFileName, extension, fullfile(get_gitPath('current-studies'), audFileLoc), fullfile(get_gitPath('free-speech'), audFileLoc))) %#ok<SPERR> 
     end
 end
 

--- a/experiment_helpers/run_measureFormants_audapter.m
+++ b/experiment_helpers/run_measureFormants_audapter.m
@@ -39,8 +39,8 @@ Audapter('deviceName', audioInterfaceName);
 %set files for vowel tracking
 if isfield(expt,'trackingFileName')
     if strcmp(expt.trackingFileLoc, 'experiment_helpers')
-        ostFN = fullfile(get_gitPath, 'free-speech', expt.trackingFileLoc, [expt.trackingFileName 'Working.ost']); 
-        pcfFN = fullfile(get_gitPath, 'free-speech', expt.trackingFileLoc, [expt.trackingFileName 'Working.pcf']); 
+        ostFN = fullfile(get_gitPath('free-speech'), expt.trackingFileLoc, [expt.trackingFileName 'Working.ost']); 
+        pcfFN = fullfile(get_gitPath('free-speech'), expt.trackingFileLoc, [expt.trackingFileName 'Working.pcf']); 
     else %it's in current-studies repo
         ostFN = fullfile(get_exptRunpath(expt.trackingFileLoc, [expt.trackingFileName 'Working.ost'])); 
         pcfFN = fullfile(get_exptRunpath(expt.trackingFileLoc, [expt.trackingFileName 'Working.pcf'])); 

--- a/experiment_helpers/run_measureFormants_audapterMEG.m
+++ b/experiment_helpers/run_measureFormants_audapterMEG.m
@@ -56,8 +56,8 @@ Audapter('deviceName', audioInterfaceName);
 %set files for vowel tracking
 if isfield(expt,'trackingFileName')
     if strcmp(expt.trackingFileLoc, 'experiment_helpers')
-        ostFN = fullfile(get_gitPath, 'free-speech', expt.trackingFileLoc, [expt.trackingFileName 'Working.ost']); 
-        pcfFN = fullfile(get_gitPath, 'free-speech', expt.trackingFileLoc, [expt.trackingFileName 'Working.pcf']); 
+        ostFN = fullfile(get_gitPath('free-speech'), expt.trackingFileLoc, [expt.trackingFileName 'Working.ost']); 
+        pcfFN = fullfile(get_gitPath('free-speech'), expt.trackingFileLoc, [expt.trackingFileName 'Working.pcf']); 
     else %it's in current-studies repo
         ostFN = fullfile(get_exptRunpath(expt.trackingFileLoc, [expt.trackingFileName 'Working.ost'])); 
         pcfFN = fullfile(get_exptRunpath(expt.trackingFileLoc, [expt.trackingFileName 'Working.pcf'])); 

--- a/experiment_helpers/set_ost.m
+++ b/experiment_helpers/set_ost.m
@@ -104,15 +104,15 @@ try newParam3Value = varargin{4}; catch; end
 % this function.
 % Get the name of the OST, take out any .ost extensions if they exist
 if strcmp(audFileDir, 'experiment_helpers') || strcmp(audFileName, 'measureFormants')
-    trackingPath = fullfile(get_gitPath, 'free-speech', 'experiment_helpers'); 
+    trackingPath = fullfile(get_gitPath('free-speech'), 'experiment_helpers'); 
 elseif isfolder(audFileDir) %if audFileDir was provided as full path
     if contains(audFileDir,'/') || contains(audFileDir,'\')
         trackingPath = audFileDir;
     else
-        trackingPath = fullfile(get_gitPath, 'current-studies', audFileDir);
+        trackingPath = fullfile(get_gitPath('current-studies'), audFileDir);
     end
 else
-    trackingPath = fullfile(get_gitPath, 'current-studies', audFileDir); 
+    trackingPath = fullfile(get_gitPath('current-studies'), audFileDir); 
 end
 
 ostFile = fullfile(trackingPath,[audFileName 'Working.ost']);

--- a/experiment_helpers/set_pcf.m
+++ b/experiment_helpers/set_pcf.m
@@ -94,15 +94,15 @@ if nargin < 3 || isempty(timeSpace), timeSpace = 'time'; end
 % this function.
 
 if strcmp(audFileName, 'measureFormants') || strcmp(audFileDir, 'experiment_helpers') % So theoretically you could be doing some OTHER PCF file that is in experiment_helpers
-    exptDir = fullfile(get_gitPath, 'free-speech', audFileDir); % could potentially hard-code this to experiment_helpers but... 
+    exptDir = fullfile(get_gitPath('free-speech'), audFileDir); % could potentially hard-code this to experiment_helpers but... 
 elseif isfolder(audFileDir)
     if contains(audFileDir,'/') || contains(audFileDir,'\')
         exptDir = audFileDir;
     else
-        exptDir = fullfile(get_gitPath, 'current-studies', audFileDir);
+        exptDir = fullfile(get_gitPath('current-studies'), audFileDir);
     end
 else
-    exptDir = fullfile(get_gitPath, 'current-studies', audFileDir); % ['C:\Users\Public\Documents\software\current-studies\' audFileLoc]; 
+    exptDir = fullfile(get_gitPath('current-studies'), audFileDir); % ['C:\Users\Public\Documents\software\current-studies\' audFileLoc]; 
 end
 
 pcfName = [audFileName 'Working.pcf']; 

--- a/templates/modelExpt/run_modelExpt_audapter.m
+++ b/templates/modelExpt/run_modelExpt_audapter.m
@@ -40,7 +40,7 @@ lastTrial = find(expt.allConds == find(strcmp(expt.conds, conds2run{end})), 1, '
 
 %% setup for audapter
 
-helpersDir = fullfile(get_gitPath, 'free-speech', expt.trackingFileLoc);
+helpersDir = fullfile(get_gitPath('free-speech'), expt.trackingFileLoc);
     %[ For modelExpt, we use very simple [[OST and PCF files]]
     %that only try to find landmarks for vowel onset and vowel offset.
 ostFN = fullfile(helpersDir, [expt.trackingFileName 'Working.ost']);


### PR DESCRIPTION
1. Rework `get_gitPathm.` so it takes an input argument of the repository you want to return a path to. @carrien I just used exactly the code you sent me -- it worked and I didn't see any issues with it.
2. Fix calls to `get_gitPath` so they use the new format appropriately.

This PR should be merged at the same time as the [corresponding PR in the current-studies repo](https://github.com/blab-lab/current-studies/pull/30). 