### PR TITLE
Go to previous trial for audioGUI. Clearer 'are you sure?' overwrite message

### DIFF
--- a/speech/audioGUI.m
+++ b/speech/audioGUI.m
@@ -126,7 +126,7 @@ while ~strcmp(endstate.name, 'end')
     if isempty(sigproc_params)
         if exist('wvp','var') % otherwise, use param file if it exists
             sigproc_params = wvp.sigproc_params;
-        elseif exist('endstate','var') % otherwise, use last trial's params
+        elseif exist('endstate','var') && isfield(endstate, 'sigproc_params') % otherwise, use last trial's params
             sigproc_params = endstate.sigproc_params;
         else % otherwise, get defaults
             sigproc_params = get_sigproc_defaults;
@@ -135,7 +135,7 @@ while ~strcmp(endstate.name, 'end')
     if isempty(plot_params) %separate out where to look for plot_params and sigproc_params
         if exist('wvp','var') % otherwise, use param file if it exists
             plot_params = wvp.plot_params;
-        elseif exist('endstate','var') % otherwise, use last trial's params
+        elseif exist('endstate','var') && isfield(endstate, 'plot_params') % otherwise, use last trial's params
             plot_params = endstate.plot_params;
         else % otherwise, get defaults
             plot_params = get_plot_defaults;

--- a/speech/audioGUI.m
+++ b/speech/audioGUI.m
@@ -67,7 +67,7 @@ while ~strcmp(endstate.name, 'end')
         if endstate.jumpto_trial < 1 
             endstate.jumpto_trial = 1;
         elseif endstate.jumpto_trial > length(data)
-            endstate.jumpto_trial = lenght(data);
+            endstate.jumpto_trial = length(data);
         end
         trials2track = endstate.jumpto_trial:length(data); % after Jump, if press Cont, just go in order after that
         itrial = 1;

--- a/speech/audioGUI.m
+++ b/speech/audioGUI.m
@@ -63,18 +63,7 @@ end
 endstate.name = '';
 itrial = 1;
 while ~strcmp(endstate.name, 'end')
-    if strcmp(endstate.name,'jump')
-        if endstate.jumpto_trial < 1 
-            endstate.jumpto_trial = 1;
-        elseif endstate.jumpto_trial > length(data)
-            endstate.jumpto_trial = length(data);
-        end
-        trials2track = endstate.jumpto_trial:length(data); % after Jump, if press Cont, just go in order after that
-        itrial = 1;
-    end
-
     trialNum = trials2track(itrial); % trialNum used during this loop
-    itrial = itrial + 1; % increment itrial for next loop
 
     %% prepare inputs
     y = data(trialNum).(buffertype);
@@ -181,6 +170,16 @@ while ~strcmp(endstate.name, 'end')
     
     if strcmp(endstate.name,'cont') && trialNum == trials2track(end) % finish if continued on final trial
         endstate.name = 'end';
+    end
+    
+    if strcmp(endstate.name, 'previous')
+        if itrial > 1
+            itrial = itrial - 1;
+        else
+            % if on 1st trial and press 'previous', just stay on 1st trial
+        end
+    else
+        itrial = itrial + 1;
     end
 end
 

--- a/utils/savecheck.m
+++ b/utils/savecheck.m
@@ -9,6 +9,10 @@ if exist(savefile, ftype)
     dlgOpts.Interpreter = 'tex';
     [path, name, extension] = fileparts(savefile);
     path = strrep(path, '\', '/');
+    path = addTexEscapeChars(path);
+    name = addTexEscapeChars(name);
+    extension = addTexEscapeChars(extension);
+
     colored_nameExt = sprintf('%s%s%s%s', '\color{blue}', name, extension, '\color{black}');
 
     % uses TeX formatting to change color and font size. See questdlg
@@ -28,6 +32,15 @@ if exist(savefile, ftype)
 
 else % file doesn't exist; nothing to overwrite; safe to save
     bSave = 1;
+
+end
+
+
+function text = addTexEscapeChars(text)
+specialChars = {'#' '$' '%' '&' '_' '{' '}'};
+for char = specialChars
+    text = strrep(text, char{1}, sprintf('%s%s', '\', char{1}));
+end
 
 end
 

--- a/utils/savecheck.m
+++ b/utils/savecheck.m
@@ -4,16 +4,32 @@ function [bSave] = savecheck(savefile,ftype)
 if nargin < 2, ftype = 'file'; end
 
 if exist(savefile, ftype)
-    messg = sprintf('The %s %s exists.  Do you want to overwrite?',ftype,savefile);
-    button = questdlg(messg,'File exists','Overwrite','Cancel','Cancel');
-    
-    switch button
+    % setup for question box
+    dlgOpts.Default = 'Cancel';
+    dlgOpts.Interpreter = 'tex';
+    [path, name, extension] = fileparts(savefile);
+    path = strrep(path, '\', '/');
+    colored_nameExt = sprintf('%s%s%s%s', '\color{blue}', name, extension, '\color{black}');
+
+    % uses TeX formatting to change color and font size. See questdlg
+    % documentation for help.
+    messg = sprintf('%sThere is already a %s named %s here:\n\n%s\n\nDo you want to overwrite %s?', ...
+        '\fontsize{10}', ftype, colored_nameExt, path, colored_nameExt);
+
+    % present the question box
+    response = questdlg(messg,'File exists','Overwrite','Cancel', dlgOpts);
+
+    switch response
         case 'Overwrite'
             bSave = 1;
         case 'Cancel'
             bSave = 0;
     end
-    
-else bSave = 1;
-    
+
+else % file doesn't exist; nothing to overwrite; safe to save
+    bSave = 1;
+
 end
+
+
+end %EOF

--- a/utils/savecheck.m
+++ b/utils/savecheck.m
@@ -9,6 +9,8 @@ if exist(savefile, ftype)
     dlgOpts.Interpreter = 'tex';
     [path, name, extension] = fileparts(savefile);
     path = strrep(path, '\', '/');
+
+    % escape tex special characters
     path = addTexEscapeChars(path);
     name = addTexEscapeChars(name);
     extension = addTexEscapeChars(extension);
@@ -36,13 +38,13 @@ else % file doesn't exist; nothing to overwrite; safe to save
 end
 
 
-function text = addTexEscapeChars(text)
-specialChars = {'#' '$' '%' '&' '_' '{' '}'};
-for char = specialChars
-    text = strrep(text, char{1}, sprintf('%s%s', '\', char{1}));
-end
+    function text = addTexEscapeChars(text) % escape characters that would otherwise be considered tex commands
+    specialChars = {'#' '$' '%' '&' '_' '{' '}'};
+    for char = specialChars
+        text = strrep(text, char{1}, sprintf('%s%s', '\', char{1}));
+    end
 
-end
+    end
 
 
 end %EOF


### PR DESCRIPTION
This PR is associated with [another one](https://github.com/blab-lab/wave_viewer/pull/4) in blab-lab/wave_viewer.

1. Changes were necessary in `audioGUI.m` to accommodate the jump-to trial functionality in wave_viewer. Namely, the `for` loop on L63 is now a `while` loop, so that the trial number can dynamically change between iterations of the loop.
2. `savecheck` is what displays the "are you sure you want to overwrite that file?" popup used in many lab functions. `savecheck` was heavily revised. It now displays a different message which splits out the filepath from filename. It also uses TeX formatting now, which allows for coloring in the file name for emphasis, and increasing the font size. Using TeX required some additional code to accommodate special characters not being interpreted as TeX commands.

Old `savecheck` prompt
![image](https://user-images.githubusercontent.com/50926971/168157443-d9eeccef-d88a-4fdb-887f-520860835c0e.png)

New `savecheck` prompt
![image](https://user-images.githubusercontent.com/50926971/168156708-dda6868b-8fc1-464c-a28e-37808016e6e2.png)
