### PR TITLE
Add input arg for expt.inds element names to set_exptDefaults

### DIFF
--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -1,9 +1,10 @@
-function [expt] = set_exptDefaults(expt)
+function [expt] = set_exptDefaults(expt, indsElements)
 %SET_EXPTDEFAULTS  Set missing experiment parameters to defaults.
 %   SET_EXPTDEFAULTS(EXPT) replaces missing fields in EXPT with default
 %   values for those fields.
 
 if nargin < 1 || isempty(expt), expt = struct; end
+if nargin < 2, indsElements = []; end
 
 fprintf('Setting defaults...\n\n');
 expt = set_missingField(expt,'name','default');
@@ -144,7 +145,7 @@ expt = set_missingField(expt,'crashTrials',[]);
 
 %% trial indices
 
-expt.inds = get_exptInds(expt);
+expt.inds = get_exptInds(expt, indsElements);
 
 fprintf('Done setting defaults.\n');
 

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -140,7 +140,7 @@ expt = set_missingField(expt,'crashTrials',[]);
 
 %% trial indices
 
-expt.inds = get_exptInds(expt,{'conds', 'words', 'vowels', 'colors', 'shiftNames'});
+expt.inds = get_exptInds(expt);
 
 fprintf('Done setting defaults.\n');
 

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -94,15 +94,14 @@ expt = set_missingField(expt,'shiftAngles',zeros(1,expt.ntrials));
 % actual stimulus string shown to participant
 expt = set_missingField(expt,'stimulusText',expt.words);
 expt = set_missingField(expt,'allStimulusText',expt.allWords);
-try
-    if all(strcmp(expt.words, expt.stimulusText))
-        expt = set_missingField(expt,'listStimulusText',expt.listWords);
-    else  %, make list from stimulusText instead of words
-        expt = set_missingField(expt,'listStimulusText',expt.stimulusText(expt.allStimulusText));
-    end
-catch
-    error(['Possible mismatch between length of expt.words of expt.stimulusText. ' ...
+if length(expt.words) ~= length(expt.stimulusText)
+    error(['Mismatch between length of expt.words of expt.stimulusText. ' ...
         'Those fields should have the same number of string elements.'])
+end
+if all(strcmp(expt.words, expt.stimulusText))
+    expt = set_missingField(expt,'listStimulusText',expt.listWords);
+else  %, make list from stimulusText instead of words
+    expt = set_missingField(expt,'listStimulusText',expt.stimulusText(expt.allStimulusText));
 end
 
 %% stimulus timing parameters, in seconds

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -91,10 +91,6 @@ expt = set_missingField(expt,'listColors',expt.colors(expt.allColors));
 expt = set_missingField(expt,'shiftMags',zeros(1,expt.ntrials));
 expt = set_missingField(expt,'shiftAngles',zeros(1,expt.ntrials));
 
-expt = set_missingField(expt,'shiftNames', {'noShift'});
-expt = set_missingField(expt,'allShiftNames',randi(length(expt.shiftNames),[1,expt.ntrials]));
-expt = set_missingField(expt,'listShiftNames',expt.shiftNames(expt.allShiftNames));
-
 % actual stimulus string shown to participant
 expt = set_missingField(expt,'stimulusText',expt.words);
 expt = set_missingField(expt,'allStimulusText',expt.allWords);

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -91,6 +91,10 @@ expt = set_missingField(expt,'listColors',expt.colors(expt.allColors));
 expt = set_missingField(expt,'shiftMags',zeros(1,expt.ntrials));
 expt = set_missingField(expt,'shiftAngles',zeros(1,expt.ntrials));
 
+expt = set_missingField(expt,'shiftNames', {'noShift'});
+expt = set_missingField(expt,'allShiftNames',randi(length(expt.shiftNames),[1,expt.ntrials]));
+expt = set_missingField(expt,'listShiftNames',expt.shiftNames(expt.allShiftNames));
+
 % actual stimulus string shown to participant
 expt = set_missingField(expt,'stimulusText',expt.words);
 expt = set_missingField(expt,'allStimulusText',expt.allWords);
@@ -139,7 +143,8 @@ expt = set_missingField(expt,'isRestart',0);
 expt = set_missingField(expt,'crashTrials',[]);
 
 %% trial indices
-expt.inds = get_exptInds(expt,{'conds', 'words', 'vowels', 'colors'});
+
+expt.inds = get_exptInds(expt,{'conds', 'words', 'vowels', 'colors', 'shiftNames'});
 
 fprintf('Done setting defaults.\n');
 

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -94,10 +94,15 @@ expt = set_missingField(expt,'shiftAngles',zeros(1,expt.ntrials));
 % actual stimulus string shown to participant
 expt = set_missingField(expt,'stimulusText',expt.words);
 expt = set_missingField(expt,'allStimulusText',expt.allWords);
-if all(strcmp(expt.words, expt.stimulusText)) 
-    expt = set_missingField(expt,'listStimulusText',expt.listWords);
-else  %, make list from stimulusText instead of words
-    expt = set_missingField(expt,'listStimulusText',expt.stimulusText(expt.allStimulusText));
+try
+    if all(strcmp(expt.words, expt.stimulusText))
+        expt = set_missingField(expt,'listStimulusText',expt.listWords);
+    else  %, make list from stimulusText instead of words
+        expt = set_missingField(expt,'listStimulusText',expt.stimulusText(expt.allStimulusText));
+    end
+catch
+    error(['Possible mismatch between length of expt.words of expt.stimulusText. ' ...
+        'Those fields should have the same number of string elements.'])
 end
 
 %% stimulus timing parameters, in seconds

--- a/utils/get_exptInds.m
+++ b/utils/get_exptInds.m
@@ -3,6 +3,20 @@ function [inds] = get_exptInds(expt,elements)
 %   GET_EXPTINDS(EXPT,ELEMENTS)
 
 allElements = cell(1,length(elements));
+goodIxs = [];
+
+% remove elements without both expt.element and expt.allElements
+for ie = 1:length(elements)
+    allElements{ie} = sprintf('all%s%s',upper(elements{ie}(1)),elements{ie}(2:end));
+    if isfield(expt, elements{ie}) && isfield(expt, allElements{ie}) && ...
+            ~isempty(expt.(elements{ie})) && ~isempty(expt.(allElements{ie}))
+        goodIxs = [goodIxs ie]; %#ok<AGROW> 
+    end
+end
+
+elements = elements(goodIxs);
+allElements = cell(1, length(elements));
+
 for ie=1:length(elements)
     allElements{ie} = sprintf('all%s%s',upper(elements{ie}(1)),elements{ie}(2:end));
     for ia=1:length(expt.(elements{ie}))

--- a/utils/get_exptInds.m
+++ b/utils/get_exptInds.m
@@ -1,20 +1,48 @@
 function [inds] = get_exptInds(expt,elements)
 %GET_EXPTINDS  Calculate indices of trial types for an expt object.
 %   GET_EXPTINDS(EXPT,ELEMENTS)
+%  EXPT: required.
+%  ELEMENTS: optional. Cell array of strings. If provided, function will
+%    make fields in expt.inds with the strings from ELEMENTS. If left
+%    empty, function will search EXPT for fields named X and allX and make
+%    fields in expt.inds using X.
 
-allElements = cell(1,length(elements));
-goodIxs = [];
+%% determine which elements to put in inds
+if nargin < 2 || isempty(elements)
+    elements = cell(0, 1);
 
-% remove elements without both expt.element and expt.allElements
-for ie = 1:length(elements)
-    allElements{ie} = sprintf('all%s%s',upper(elements{ie}(1)),elements{ie}(2:end));
-    if isfield(expt, elements{ie}) && isfield(expt, allElements{ie}) && ...
-            ~isempty(expt.(elements{ie})) && ~isempty(expt.(allElements{ie}))
-        goodIxs = [goodIxs ie]; %#ok<AGROW> 
+    % get names of fields in expt
+    fields = fieldnames(expt);
+
+    % loop over fields that contain 'all'
+    for fIx = find(contains(fields, 'all'))'
+
+        % only consider fields that begin with 'all' and then have an uppercase
+        % letter immediately after (eg, 'allWords')
+        if length(fields{fIx}) > 3 && matches(fields{fIx}(1:3), 'all') && isstrprop(fields{fIx}(4), 'upper')
+
+            % get the version of the field name without 'all' at the start (eg, 'words')
+            element = sprintf('%s%s', lower(fields{fIx}(4)), fields{fIx}(5:end));
+
+            % check if a field exists with that name
+            element_ix = find(matches(fields, element));
+            if element_ix
+
+                % make sure the contents of that field could become field names
+                % in expt.inds. For example, fields whose contents are
+                % numeric such as [0] cannot be a field name.
+                try
+                    if isvarname(expt.(fields{element_ix}) {1})     % eg, expt.(words){1} = 'bed' --> OK
+                        elements(length(elements)+1) = fields(element_ix);
+                    end
+                catch
+                end
+            end
+        end
     end
 end
 
-elements = elements(goodIxs);
+%% generate inds
 allElements = cell(1, length(elements));
 
 for ie=1:length(elements)


### PR DESCRIPTION
Fix issue from #34 where there's no input argument in `set_exptDefaults` to get passed to `get_exptInds`, the main workflow.