### PR TITLE
Additions to adjustOsts and plot_duration_feedback for taimComp

### DIFF
--- a/experiment_helpers/adjustOsts.m
+++ b/experiment_helpers/adjustOsts.m
@@ -143,7 +143,7 @@ compiledData = [];
 for t = 1:length(trials2compile)
     trialNo = trials2compile(t); 
     load(fullfile(tempdir, [num2str(trialNo) '.mat']), 'data'); 
-    data.trialNo = trialNo; 
+    data.trial = trialNo; 
     compiledData = [compiledData; data]; 
 end
     

--- a/experiment_helpers/adjustOsts.m
+++ b/experiment_helpers/adjustOsts.m
@@ -1,12 +1,31 @@
-function [] = adjustOsts(expt, h_fig)
+function [] = adjustOsts(expt, h_fig, word, trackingFileName)
 % This function will be used by the button "Adjust OSTs" in the control window of an experiment display. The purpose of this
 % is to adjust the OST files for a participant mid-experiment, if they have changed their speech such that the OSTs are no
 % longer working (especially talking louder or something, where your thresholds may no longer be accurate)
+% 
+% INPUT ARGUMENTS: 
+%       expt:           
+%           expt structure from the experiment. For the sake of audpater_viewer this turns into exptOst (so it can be saved,
+%           and then resaved over with the originals)
+%       h_fig:
+%           Figure handle from the experiment, so pause text can be appropriately included 
+%       word:           
+%           the word to look for in expt.inds.words. If empty or does not exist, just assumes that all trials should be used.
+%           Use this when you are in an experiment that has multiple OST files, such as taimComp. If you have multiple words
+%           that use one OST file (e.g., both "size" and "sigh" use some OST file called "sigh"), you can put in a cell array
+%           {'size' 'sigh'} and the indices from expt.inds.words.size and expt.inds.words.sigh will be concatenated
+%       ostFN:       
+%           the name of the OST file, same use patterns as other trackingFileName arguments (i.e., 'size' would look for
+%           sizeWorking in expt.trackingFileLoc). If this is empty, and word is also empty, just uses expt.trackingFileName.
+%           If it is empty and word is NOT empty, uses the first word in word. 
+%           
 % 
 % Process: 
 % 1. Takes in expt and h_fig (so that you can run a split version of pause_trial) 
 % 2. Compiles data from last 18 temp trials into one data file so it can be read by audapter_viewer all at once (if you don't
 % have 18, it will just take the last however many you have) 
+% --- If you are in an experiment that has multiple OST files (e.g. taimComp), the argument "trialSubset" will tell the
+% script which trials are acceptable
 % 3. Opens audapter_viewer with that data file and the expt 
 % 4. Use audapter_viewer as normal 
 % 5. Marks last temporary trial 1 for bChangedOsts
@@ -19,10 +38,36 @@ function [] = adjustOsts(expt, h_fig)
 % Accompanies function add_adjustOstButton to add a button to control screen to get to this script
 % 
 % Initiated RPK 6/2/2021
+% Major change RPK 2022-01-03 to accommodate multiple OST files, for taimComp
 % 
 % 
 
 dbstop if error 
+%% Default arguments
+
+if nargin < 3 || isempty(word), word = ''; end
+if nargin < 4 || isempty(trackingFileName)
+    if nargin < 3 || isempty(word)
+        if ~isfield(expt, 'trackingFileName')
+            trackingFileName = 'measureFormants'; 
+        else
+            trackingFileName = expt.trackingFileName; 
+        end
+    elseif iscell(word)
+        trackingFileName = word{1}; 
+    else
+        trackingFileName = word; 
+    end
+end
+
+% Change string inputs in word to cell 
+if ischar(word)
+    word = {word}; 
+end
+
+% Set exptOst so that you don't lose original expt 
+exptOst = expt; 
+exptOst.trackingFileName = trackingFileName; 
 
 %% Display faux pause information (without actually pausing) 
 get_figinds_audapter;
@@ -49,12 +94,12 @@ CloneFig(h_fig(stim),h_fig(dup))
 nCompiledTrials = 18; 
 
 % OST file information 
-if (~isfield(expt, 'trackingFileDir') && ~isfield(expt, 'trackingFileLoc')) 
+if (~isfield(exptOst, 'trackingFileDir') && ~isfield(exptOst, 'trackingFileLoc')) 
     trackingFileDir = 'experiment_helpers'; 
-elseif isfield(expt, 'trackingFileDir')
-    trackingFileDir = expt.trackingFileDir; 
-elseif isfield(expt, 'trackingFileLoc')
-    trackingFileDir = expt.trackingFileLoc; 
+elseif isfield(exptOst, 'trackingFileDir')
+    trackingFileDir = exptOst.trackingFileDir; 
+elseif isfield(exptOst, 'trackingFileLoc')
+    trackingFileDir = exptOst.trackingFileLoc; 
 end
 
 if strcmp(trackingFileDir, 'experiment_helpers')
@@ -63,19 +108,13 @@ else
     ostPath = get_exptRunpath(trackingFileDir); 
 end
 
-if ~isfield(expt, 'trackingFileName')
-    trackingFileName = 'measureFormants'; 
-else
-    trackingFileName = expt.trackingFileName; 
-end
-
 ostWorking = fullfile(ostPath, [trackingFileName 'Working.ost']); 
  
 
 %% Get temporary data files
 
 % Look for temporary trial directory
-tempdirs = regexp(genpath(expt.dataPath),'[^;]*temp_trials','match')';
+tempdirs = regexp(genpath(exptOst.dataPath),'[^;]*temp_trials','match')';
 if isempty(tempdirs)
     % If there isn't one
     fprintf('No trials left to adjust OSTs for.\n')
@@ -85,18 +124,26 @@ elseif length(tempdirs) > 1
     return;
 end
 
-compiledData = []; 
-
 tempdir = tempdirs{1}; 
 trialnums = get_sortedTrials(tempdir);
 
+% Get trials in the allowed subset (e.g., just ones in expt.inds.words.sigh)
+allowedTrials = []; 
+for w = 1:length(word)
+    allowedTrials = [allowedTrials exptOst.inds.words.(word{w})]; 
+end
+trialnums = intersect(allowedTrials, trialnums); % Get the intersection of the subset of trials and the completed trials in temp
+
 % Get last nCompiledTrials trials (finds the integers so that you get a full indexed list) 
 trials2compile = find(round(trialnums) == trialnums, nCompiledTrials, 'last'); 
-trials2compile = trialnums(trials2compile); % Just in case your trial list for some reason doesn't start at 1 
+trials2compile = trialnums(trials2compile); % Just in case your trial list for some reason doesn't start at 1 ... like if you're only doing a subset
 
+% Compile the data into a data.mat
+compiledData = []; 
 for t = 1:length(trials2compile)
     trialNo = trials2compile(t); 
     load(fullfile(tempdir, [num2str(trialNo) '.mat']), 'data'); 
+    data.trialNo = trialNo; 
     compiledData = [compiledData; data]; 
 end
     
@@ -108,12 +155,12 @@ save(fullfile(tempdir, [num2str(max(trials2compile)), '.mat']), 'data');
 % Clear data and save full compiled data as data_ostChange.mat
 clear data; 
 data = compiledData; 
-save(fullfile(expt.dataPath, 'data_ostChange.mat'), 'data'); % Unclear if we actually need to save this
+save(fullfile(exptOst.dataPath, 'data_ostChange.mat'), 'data'); % Unclear if we actually need to save this
 
 %% Open audapter viewer
 
 % Using data (which is now compiledData)
-audapter_viewer(data,expt); 
+audapter_viewer(data,exptOst); 
 hGui = findobj('Tag','audapter_viewer'); 
 
 % Pause the experiment
@@ -134,6 +181,10 @@ set(h_fig(dup),'CurrentCharacter','@')
 % Send in new values to audapter before resetting text
 Audapter('ost', ostWorking, 0);
 fprintf('New OST values fed into Audapter.\n')
+
+% Resave expt
+save(fullfile(expt.dataPath, 'expt.mat'), 'expt'); % Because in some cases you may have changed expt to have a different trackingFileName 
+fprintf('Original expt structure saved'); 
 
 % Refresh text
 delete_exptText(h_fig, h_text)

--- a/experiment_helpers/adjustOsts.m
+++ b/experiment_helpers/adjustOsts.m
@@ -65,6 +65,10 @@ dbstop if error
 %% Default arguments
 
 if nargin < 3 || isempty(word), word = {}; end
+% Change string inputs in word to cell 
+if ischar(word)
+    word = {word}; 
+end
 if nargin < 4 || isempty(trackingFileName)
     if nargin < 3 || isempty(word)
         if ~isfield(expt, 'trackingFileName')
@@ -74,15 +78,10 @@ if nargin < 4 || isempty(trackingFileName)
         end
     elseif iscell(word)
         trackingFileName = word{1}; 
-    else
-        trackingFileName = word; 
     end
 end
 
-% Change string inputs in word to cell 
-if ischar(word)
-    word = {word}; 
-end
+
 
 % Set exptOst so that you don't lose original expt 
 exptOst = expt; 

--- a/experiment_helpers/adjustOsts.m
+++ b/experiment_helpers/adjustOsts.m
@@ -20,6 +20,22 @@ function [] = adjustOsts(expt, h_fig, word, trackingFileName)
 %           If it is empty and word is NOT empty, uses the first word in word. 
 %           *** NOTE: this is a separate argument because expt.trackingFileName may include multiple tracking file names for
 %           experiments with multiple tracking files, such as taimComp. 
+% 
+% Note for usage in experiments proper: because the pause function for adjustOst is only checked at the beginning of a trial,
+% one way to call adjustOsts on 'a' press is to use the word from the last trial, i.e. 
+% 
+%       adjustOsts(expt, h_fig, expt.listWords(trial_index - 1), expt.trackingFileName(expt.allWords(trial_index - 1))
+% 
+% For this usage, the experimenter would press 'a' during a trial that has the questionable word, and then right before the
+% next trial started, adjustOsts would fire up. 
+% 
+% An alternative way to call this would be to use something like askNChoiceQuestion to determine what words to feed in, e.g. 
+% 
+%       word2adjust = askNChoicQuestion('What word would you like to adjust the OSTs for?', {'sigh' 'size' 'buyYogurt'}; 
+%       adjustOsts(expt, h_fig, word2adjust, []); 
+% 
+% Where the empty argument for trackingFileName would look for an OST file named with word2adjust. Depending on your
+% particular experiment structure you can tailor exactly how you want to call adjustOsts in your experiment engine. 
 %           
 %           
 % 
@@ -194,7 +210,7 @@ fprintf('New OST values fed into Audapter.\n')
 
 % Resave expt
 save(fullfile(expt.dataPath, 'expt.mat'), 'expt'); % Because in some cases you may have changed expt to have a different trackingFileName 
-fprintf('Original expt structure saved'); 
+fprintf('Original expt structure saved.\n'); 
 
 % Refresh text
 delete_exptText(h_fig, h_text)

--- a/experiment_helpers/plot_duration_feedback.m
+++ b/experiment_helpers/plot_duration_feedback.m
@@ -16,13 +16,27 @@ function [h_dur,success,vowel_dur] = plot_duration_feedback(h_fig, data, params,
 %      bMeasureOst:     If 1, measure vowel length via duration of ost
 %                       status specified in ostTrigger. Default 0.
 %      badtrack_min_dur:    added for taimComp. Provides absolute minimum 
-%                           duration to be considered an okay OST track 
+%                           duration to be considered an okay OST track (in s). 
+%                           Defaults to 0.05 seconds
 %      badtrack_max_dur:    added for taimComp. Provides absolute maximum 
-%                           duration to be considered an okay OST track 
+%                           duration to be considered an okay OST track (in s). 
+%                           Defaults to 1 second
 %   ostTrigger:     The ost status used to measure duration. Only used if
 %                   params.bMeasureOst==1. Default [].
-%   bConsiderBadtracks:     flag to consider bad tracking min/max (independent 
-%                           of bOstStuck, but similar guardrail) 
+% 
+%   *** RPK addition for taimComp: 
+%   bConsiderBadtracks:     flag to treat improbable values as the result of poor OST tracking rather than speech rate 
+%                           issues. Defaults to 0 (compatible with other non-OST defaults). 
+%                           If you flag this as 1, durations that are beyond what you specify in params.badtrack_min_dur and 
+%                           params.badtrack_max_dur are not treated as too short/too long but rather as spoken unclearly. 
+%                           This will only do anything if you have params.bMeasureOst set to 1. 
+% 
+%                           Note: this is distinct from the function performed by bOstStuck in the script proper, which just
+%                           checks if the OST never advanced to the next stage at all. 
+% 
+% NC? initiated 2020
+% CWN 02/2021 added functionality for using OSTs instead of amplitude thresholds 
+% RPK 01/2022 added option to disregard probable bad OST tracking instead of giving duration feedback
 
 
 if nargin < 3 || isempty(params), params = []; end
@@ -123,7 +137,7 @@ if params.bMeasureOst && bOstStuck
     h_dur(1) = viscircles(center,.05,'Color',[1 0.5 0]); %orange
     h_dur(2) = text(params.circ_pos(1)+0.05,params.circ_pos(2)-0.1,{'Speak a little clearer'}, 'Color', [1 0.5 0], 'FontSize', 30,'HorizontalAlignment','Center');
     success = 0;
-elseif bConsiderBadtracks && (vowel_dur < params.badtrack_min_dur || vowel_dur > params.badtrack_max_dur)
+elseif params.bMeasureOst && bConsiderBadtracks && (vowel_dur < params.badtrack_min_dur || vowel_dur > params.badtrack_max_dur)
     % taimComp addition for probable OST problems INCLUDING rushing (not just OST getting stuck) 
     h_dur(1) = viscircles(center,.05,'Color',[1 0.5 0]); %orange
     h_dur(2) = text(params.circ_pos(1)+0.05,params.circ_pos(2)-0.1,{'Speak a little clearer'}, 'Color', [1 0.5 0], 'FontSize', 30,'HorizontalAlignment','Center');


### PR DESCRIPTION
Two changes to experiments that are broadly used in different experiments to have more functionality for taimComp specifically (but can be applicable to other experiments): 

1. adjustOsts: this is the function used to adjust OST settings in the middle of an experiment. Previously it would automatically take in the last 18 trials. This is fine when only a single word with a single OST file is being used. In taimComp, there are multiple words and multiple OST files. The addition allows you to specify that you want to work with some subset of files, using a "word" argument. This takes advantage of expt.inds.(words). 

trackingFileName is also optionally independently specified, for use in the case when, say, the words are "bus" and "best" but the OST is bVs 

2. plot_duration_feedback: this is the function that tells people to speak more slowly, quickly, or that their speed is good based on durations of target segments (determined in various ways). This change adds a bConsiderBadtracks flag, which is to be used alongside the OST-based durations. If you specify 1 for bConsiderBadtracks, it will consider any super anomolous durations (specified in params fed in as second argument) as likely belonging to bad tracking and will give clarity feedback rather than speed feedback. 

This is similar to badOst, but adds the possibility that all statuses may have been met but just not at reasonable landmarks. 