### PR TITLE
Bugfix for abbrev_dataPath

### DIFF
--- a/utils/abbrev_dataPath.m
+++ b/utils/abbrev_dataPath.m
@@ -6,4 +6,6 @@ basePath = get_exptLoadPath;
 
 if strncmp(dataPath,basePath,length(basePath))
     shortDataPath = dataPath(length(basePath)+1:end);
+else
+    shortDataPath = dataPath;
 end


### PR DESCRIPTION
Quick fix to avoid errors when path string doesn't match the base path set in get_exptLoadPath.