### PR TITLE
Av debug

### DIFF
--- a/audapter_viewer/audapter_viewer.m
+++ b/audapter_viewer/audapter_viewer.m
@@ -200,7 +200,7 @@ bTheseOstRecalculated = 1;
 
 % For tooltips on the OST status lines 
 p.eventNumbers = str2double(ostList); 
-p.eventNames = get_ostEventNamesNumbers_timeAdapt(trackingFileDir, trackingFileName, p.eventNumbers, 1, 0, 0); 
+p.eventNames = get_ostEventNamesNumbers(trackingFileDir, trackingFileName, p.eventNumbers, 1, 0, 0); 
 p.ostMultiplier = round((6000/(max(p.eventNumbers)+2))/10)*10; % In the future this should be changed so there are many y axes, but this works okay for now
 
 %% PCF-related stuff

--- a/audapter_viewer/get_ostEventNamesNumbers.m
+++ b/audapter_viewer/get_ostEventNamesNumbers.m
@@ -146,12 +146,12 @@ elseif strcmp(trackingFileDir, 'timeWrap')
         triggerName = eventNames{triggerNo == eventNos};
     end
     
-elseif contains(trackingFileDir, 'cerebTimeAdapt')
+elseif any(strcmp(strsplit(trackingFileDir, filesep), 'cerebTimeAdapt'))
     eventNames = {'vStart' 'sStart' 'tStart' 'tEnd'}; 
     triggerNo = 2; 
     triggerName = eventNames{triggerNo == eventNos};
     
-elseif contains(trackingFileDir, 'taimComp')
+elseif any(strcmp(strsplit(trackingFileDir, filesep), 'taimComp'))
     if strcmp(trackingFileName, 'buyYogurt')
         eventNames = {'eiStart', 'bStart', 'aiStart', 'gStart' 'erStart'};
         triggerNo = 6;

--- a/audapter_viewer/get_ostEventNamesNumbers.m
+++ b/audapter_viewer/get_ostEventNamesNumbers.m
@@ -151,7 +151,7 @@ elseif strcmp(trackingFileDir, 'cerebTimeAdapt')
     triggerNo = 2; 
     triggerName = eventNames{triggerNo == eventNos};
     
-elseif strcmp(trackingFileDir, 'taimComp')
+elseif contains(trackingFileDir, 'taimComp')
     if strcmp(trackingFileName, 'buyYogurt')
         eventNames = {'eiStart', 'bStart', 'aiStart', 'gStart' 'erStart'};
         triggerNo = 6;

--- a/audapter_viewer/get_ostEventNamesNumbers.m
+++ b/audapter_viewer/get_ostEventNamesNumbers.m
@@ -146,7 +146,7 @@ elseif strcmp(trackingFileDir, 'timeWrap')
         triggerName = eventNames{triggerNo == eventNos};
     end
     
-elseif strcmp(trackingFileDir, 'cerebTimeAdapt')
+elseif contains(trackingFileDir, 'cerebTimeAdapt')
     eventNames = {'vStart' 'sStart' 'tStart' 'tEnd'}; 
     triggerNo = 2; 
     triggerName = eventNames{triggerNo == eventNos};


### PR DESCRIPTION
debugging a couple of minor things in audapter_viewer. One is a call to the old name of get_ostEventsNamesNumbers. The other is in get_ostEventsNamesNumbers itself, using contains instead of strcmp for experiments that are now in cerebellar-battery, because they pass in a full path. This could potentially be a change to consistently implement in the future since it should be fully compatible with any form of the trackingFileDir