### PR TITLE
create default option that doesn't just return empty

### DIFF
--- a/experiment_helpers/get_experiment_function.m
+++ b/experiment_helpers/get_experiment_function.m
@@ -59,6 +59,15 @@ switch expName
     case 'simonHomophone'
         expFun = @run_simonHomophone_audapter;
     otherwise
-        fprintf('Function for experiment ''%s'' not found.',expName)
-        expFun = [];
+        % see if there's a function with the format run_'expName'_audapter
+        expFun = sprintf('run_%s_audapter', expName);
+        isFunction = which(expFun);
+        if isFunction
+            fprintf(['No explicit function name found in list in get_experiment_function.m\n' ...
+                'Using default behavior to set function name to %s\n'], expFun)
+            expFun = eval(sprintf('@%s', expFun));
+        else
+            fprintf('Function for experiment ''%s'' not found.',expName)
+            expFun = [];
+        end
 end


### PR DESCRIPTION
After making PR #76 for simonSingleWord_v2, I'm trying to prevent the need to make a PR for each new experiment. Our convention for the last few years has been relatively consistent in that experiments use the function name "run_exptName_expt" and "run_exptName_audapter".

This change is not meant to capture every future experiment name.
I am unable to think of a reasonable situation where this change would return the INCORRECT function name. It will just still fail to find the correct function name in certain situations. (As it would behave without this change.)