### PR TITLE
Set participant screen based on window orientation

### DIFF
--- a/experiment_helpers/setup_exptFigs.m
+++ b/experiment_helpers/setup_exptFigs.m
@@ -7,7 +7,15 @@ function [h_fig] = setup_exptFigs()
 
 % set figure positions
 get_figinds_audapter;
-pos{stim} = [1 0 1 1];         % participant view
+
+% check if 2nd monitor is to the right (pos. value) or left (neg. value) of main screen
+monitorPositions = get(0, 'MonitorPositions');
+if height(monitorPositions) > 1 && monitorPositions(2,1) < 0
+    pos{stim} = [-1 0 1 1];         % participant view on left screen
+else
+    pos{stim} = [1 0 1 1];         % participant view on right screen
+end
+
 pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking
 pos{dup} = [0 0.3 0.6 0.7];    % duplicate participant view for experimenter
 


### PR DESCRIPTION
Previously, `setup_exptFigs` was only designed to work with the primary monitor in the left position, and the participant's monitor in the right position. The Matlab figure with the participant's instructions was hard-coded to display to the right of the main display.

Now, we check if the second display is to the right or left of the main monitor, and display the figure on the correct screen.

I tested this with both orientations in an experiment which uses the default experiment figure setup.

This does not affect experiments where we assume there is only one screen, like the iEEG setup. Those experiments use a different function to create experiment figures.