### PR TITLE
Update gen_dataVals to sort user events

### DIFF
--- a/speech/gen_dataVals_from_wave_viewer.m
+++ b/speech/gen_dataVals_from_wave_viewer.m
@@ -112,8 +112,8 @@ for i = 1:length(sortedTrialnums)
             event_times = trialparams.event_params.user_event_times;
             event_names = trialparams.event_params.user_event_names;
 
-            [~, sortOrder] = sort(event_times(:));
-            if ~isequal(sortOrder', 1:numUserEvents) % events not ordered first-to-last
+            [~, sortOrder] = sort(event_times);
+            if ~isequal(sortOrder, 1:numUserEvents) % events not ordered first-to-last
                 fprintf('Reordering events for trial %d\n', trialnum);
                 trialparams.event_params.user_event_times = event_times(sortOrder);
                 trialparams.event_params.user_event_names = event_names(sortOrder);

--- a/speech/gen_dataVals_from_wave_viewer.m
+++ b/speech/gen_dataVals_from_wave_viewer.m
@@ -107,6 +107,21 @@ for i = 1:length(sortedTrialnums)
             numUserEvents = 0;
         end
 
+        % reorder events first-to-last
+        if numUserEvents >= 2
+            event_times = trialparams.event_params.user_event_times;
+            event_names = trialparams.event_params.user_event_names;
+
+            [~, sortOrder] = sort(event_times(:));
+            if ~isequal(sortOrder', 1:numUserEvents) % events not ordered first-to-last
+                fprintf('Reordering events for trial %d\n', trialnum);
+                trialparams.event_params.user_event_times = event_times(sortOrder);
+                trialparams.event_params.user_event_names = event_names(sortOrder);
+                save(fullfile(trialPath,filename), 'sigmat', 'trialparams');
+            end
+        end
+
+
         try
             bGoodTrial = trialparams.event_params.is_good_trial;
         catch

--- a/speech/gen_dataVals_from_wave_viewer.m
+++ b/speech/gen_dataVals_from_wave_viewer.m
@@ -101,9 +101,9 @@ for i = 1:length(sortedTrialnums)
         filename = sortedFilenames{i};
         load(fullfile(trialPath,filename), 'sigmat', 'trialparams');
 
-        try
+        if isfield(trialparams,'event_params') && isfield(trialparams.eventparams,'user_event_times')
             numUserEvents = length(trialparams.event_params.user_event_times);
-        catch
+        else
             numUserEvents = 0;
         end
 
@@ -121,10 +121,9 @@ for i = 1:length(sortedTrialnums)
             end
         end
 
-
-        try
+        if isfield(trialparams,'event_params') && isfield(trialparams.eventparams,'is_good_trial')
             bGoodTrial = trialparams.event_params.is_good_trial;
-        catch
+        else
             bGoodTrial = 1; % if field doesn't exist, assume it's good
         end
 


### PR DESCRIPTION
Sort user events first-to-last in `trialparams.event_params` within a trial, if they are not indexed in linear order. This prevents problems when generating a multisegment dataVals file, like in vsaSentence.