### PR TITLE
Create function run_checkLPC

### DIFF
--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -59,10 +59,7 @@ switch params.checkMethod
             onset = find(data.rms > 0.025, 1, 'first') + 5;
             offset = find(data.rms(:, 1)<0.03 & data.rms(:, 1)>0.015 & data.rms_slope<0, 1, 'first') - 5;
             if isempty(offset)
-                offset = onset+10;
-            end
-            if offset > length(data.rms)
-                offset = length(data.rms);
+                offset = min(onset+10,length(data.rms));
             end
 
             % use middle 80%

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -55,9 +55,12 @@ switch params.checkMethod
             rmsValue = mean(data.rms(onset:offset, 1));
 
         % if no ost tracking, use RMS data to find onset/offset
-        elseif any(data.rms(:, 1) > 0.025)
-            onset = find(data.rms > 0.025, 1, 'first') + 5;
-            offset = find(data.rms(:, 1)<0.03 & data.rms(:, 1)>0.015 & data.rms_slope<0, 1, 'first') - 5;
+        elseif any(data.rms(:, 1) > 0.03)
+            % These values are more lax versions of the settings
+            % in free-speech\experiment_helpers\measureFormants.ost. They
+            % are relatively imprecise and would benefit from more nuance in the future.
+            onset = find(data.rms > 0.03, 1, 'first') + 5;
+            offset = find(data.rms(:, 1)<0.03 & data.rms(:, 1)>0.02 & data.rms_slope<0, 1, 'first') - 5;
             if isempty(offset)
                 offset = min(onset+10,length(data.rms));
             end

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -67,7 +67,7 @@ switch params.checkMethod
             if isempty(offset)
                 offset = min(onset+10,length(data.rms));
             end
-            rmsValue = mean(data.rms(onset:offset));
+            rmsValue = mean(data.rms(onset:offset, 1));
 
         % can't determine rms mean, because no ost-based vowel found, and RMS too low
         else

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -55,9 +55,15 @@ switch params.checkMethod
             rmsValue = mean(data.rms(onset:offset, 1));
 
         % if no ost tracking, use RMS data to find onset/offset
-        elseif ~any(data.ost_stat >= 1) && any(data.rms(:, 1) > 0.03)
-            onset = find(data.rms > 0.01, 1, 'first') + 5;
-            offset = find(data.rms(:, 1)<0.03 & data.rms(:, 1)>0.02 & data.rms_slope<0, 1, 'first') - 5;
+        elseif any(data.rms(:, 1) > 0.025)
+            onset = find(data.rms > 0.025, 1, 'first') + 5;
+            offset = find(data.rms(:, 1)<0.03 & data.rms(:, 1)>0.015 & data.rms_slope<0, 1, 'first') - 5;
+            if isempty(offset)
+                offset = onset+10;
+            end
+            if offset > length(data.rms)
+                offset = length(data.rms);
+            end
 
             % use middle 80%
             onset = floor(onset + ((offset-onset)/10));

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -29,8 +29,11 @@ function bGoodTrial = check_rmsThresh(data,rmsThresh,subAxis,params)
 if nargin < 3, subAxis = []; end
 if nargin < 4
     params = struct;
+    defaultParams.checkMethod = 'peak';     % maintain legacy behavior
+else
+    defaultParams.checkMethod = 'mean';
 end
-defaultParams.checkMethod = 'mean';
+
 defaultParams.limits = [0.037, 0.100; 0 0];
 defaultParams.rmsThresh = 0.037;
 params = set_missingFields(params, defaultParams, 0);

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -67,9 +67,7 @@ switch params.checkMethod
             if isempty(offset)
                 offset = min(onset+10,length(data.rms));
             end
-
-            % use middle 80%
-            rmsValue = mean(data.rms(midnperc(onset:offset, 80), 1));
+            rmsValue = mean(data.rms(onset:offset));
 
         % can't determine rms mean, because no ost-based vowel found, and RMS too low
         else

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -66,9 +66,7 @@ switch params.checkMethod
             end
 
             % use middle 80%
-            onset = floor(onset + ((offset-onset)/10));
-            offset = ceil(offset - ((offset-onset)/10));
-            rmsValue = mean(data.rms(onset:offset, 1));
+            rmsValue = mean(data.rms(midnperc(onset:offset, 80), 1));
 
         % can't determine rms mean, because no ost-based vowel found, and RMS too low
         else

--- a/experiment_helpers/run_checkLPC.m
+++ b/experiment_helpers/run_checkLPC.m
@@ -34,7 +34,7 @@ else
     defaultParams.nblocks = 10; % number of repetitions of each word
 end
 defaultParams.amplcalc.checkMethod = 'mean';
-defaultParams.amplcalc.rmsThresh = 0; % don't automatically prompt pp to change volume during pretest phase
+defaultParams.amplcalc.rmsThresh = 0.03; % quite low amplitude required for "talk louder" message
 % amplcalc.limits is a 2x2 array structured like this:
 %        [GoodLow, GoodHi;
 %         WarnLow, WarnHi]

--- a/experiment_helpers/run_checkLPC.m
+++ b/experiment_helpers/run_checkLPC.m
@@ -1,0 +1,107 @@
+function [expt, exptPre] = run_checkLPC(expt, exptPre)
+% Runs a short speech experiment using run_measureFormants_audapter, then
+% plots formant means using check_audapterLPC. Useful for determining LPC
+% order and vowel means for participants in most speech experiments. The
+% indended use is that this will happen near the beginning of a study,
+% before the main phase. 
+% 
+% The result of this function is saving a file `exptPre`. The variable 
+% exptPre can also be passed back as an output argument.
+%
+% This function assumes the input argument `expt` has the following fields:
+%   expt.dataPath
+%   expt.snum
+%   expt.gender
+
+% 2022-11 Chris Naber init.
+
+%% setup
+if nargin < 2
+    exptPre = struct;
+end
+
+defaultParams.snum = expt.snum;
+defaultParams.gender = expt.gender;
+defaultParams.dataPath = fullfile(expt.dataPath, 'pre');
+defaultParams.words = {'bid' 'bat' 'bed'};
+defaultParams.conds = {'noShift'};
+defaultParams.trackingFileLoc = 'experiment_helpers'; % default single-syllable, one word Audapter OST file
+defaultParams.trackingFileName = 'measureFormants';   % default single-syllable, one word Audapter OST file
+defaultParams.audapterParams.fb = 3;                  % feedback mode. 3=participant hears speech and noise
+if isfield(expt, 'bTestMode') && expt.bTestMode
+    defaultParams.nblocks = 2;  % number of repetitions of each word
+else
+    defaultParams.nblocks = 10; % number of repetitions of each word
+end
+defaultParams.amplcalc.checkMethod = 'mean';
+defaultParams.amplcalc.rmsThresh = 0; % don't automatically prompt pp to change volume during pretest phase
+% amplcalc.limits is a 2x2 array structured like this:
+%        [GoodLow, GoodHi;
+%         WarnLow, WarnHi]
+% In check_rmsThresh, a line is drawn in green between the low and hi Good limits,
+% and a line in yellow between the Warn limits.
+% With these limits, the green region is 80-86 dBA on SMNG hardware.
+% Warn region is +/- another 1.5 dBA.
+defaultParams.amplcalc.limits = [0.042, 0.060; 0.037, 0.065];
+
+% reconcile exptPre and defaultParams
+exptPre = set_missingFields(exptPre, defaultParams, 0);
+
+% set settings that require reconciled exptPre and defaultParams
+if ~isfield(exptPre, 'ntrials')
+    exptPre.ntrials = exptPre.nblocks * length(exptPre.words);
+end
+if ~isfield(exptPre, 'breakTrials')
+    exptPre.breakTrials = exptPre.ntrials; % no breaks
+end
+refreshWorkingCopy(exptPre.trackingFileLoc,exptPre.trackingFileName,'both');
+if ~exist(exptPre.dataPath, 'dir')
+    mkdir(exptPre.dataPath)
+end
+
+% set remaining missing fields in exptPre to default values
+exptPre = set_exptDefaults(exptPre);
+
+%% run mini experiment and determine LPC order based on trials
+goodLPC = 'no';
+while strcmp(goodLPC, 'no')
+    %run pre-experiment data collection
+    exptPre = run_measureFormants_audapter(exptPre, exptPre.audapterParams.fb);
+
+    % Check LPC order
+    exptPre = check_audapterLPC(exptPre.dataPath); % check that they're being tracked right
+    hGui = findobj('Tag','check_LPC');
+    waitfor(hGui);
+    exptPre.fmtMeans = calc_vowelMeans(exptPre.dataPath);
+
+    % Confirm file exists. Ask user if it's OK
+    if exist(fullfile(exptPre.dataPath, 'nlpc.mat'), 'file')
+        goodLPC = askNChoiceQuestion('Was the LPC check recording good?', {'yes' 'no'});
+    else
+        fprintf('\nRe-running LPC_check section. Couldn''t find an nlpc.mat file in %s\n', exptPre.dataPath)
+    end
+end
+
+%% save it
+%set lpc order
+load(fullfile(exptPre.dataPath,'nlpc'),'nlpc') 
+p.nLPC = nlpc;
+if isfield(expt, 'audapterParams')
+    expt.audapterParams = add2struct(expt.audapterParams, p);
+else
+    expt.audapterParams = p;
+end
+
+%Get vowel formant means from expt
+exptPre.fmtMeans = calc_vowelMeans(exptPre.dataPath);
+
+% Save all info in the pre, switch back to top level expt
+exptfile = fullfile(exptPre.dataPath,'expt.mat');
+pre.expt = exptPre;
+save(exptfile, '-struct', 'pre');
+
+exptfile = fullfile(expt.dataPath,'expt.mat');
+save(exptfile, 'expt');
+fprintf('\nSaved expt file with LPC order: %s\n', exptfile);
+
+end %EOF

--- a/experiment_helpers/run_measureFormants_audapter.m
+++ b/experiment_helpers/run_measureFormants_audapter.m
@@ -29,9 +29,6 @@ stimtxtsize = 200;
 % set missing expt fields to defaults
 expt = set_exptDefaults(expt);
 
-%set RMS threshold for deciding if a trial is good or not
-rmsThresh = 0.04;
-
 %% set up audapter
 audioInterfaceName = 'Focusrite USB'; %SMNG default for Windows 10
 Audapter('deviceName', audioInterfaceName);
@@ -134,17 +131,8 @@ for itrial = 1:length(trials2run)  % for each trial
         data.bChangeOst = 0; 
 
         %plot amplitude and ost tracking
-        bGoodTrial = check_rmsThresh(data,rmsThresh,h_sub(3));
-    %     figure(h_fig(ctrl))
-    %     subplot(h_sub(3))
-    %     yyaxis left
-    %     plot(data.rms(:,1));
-    % %     ylim([0 0.1]) 
-    %     
-    %     yyaxis right
-    %     plot(data.ost_stat);
-    %     hline(0.01,'k',':');
-    %     
+        bGoodTrial = check_rmsThresh(data,[],h_sub(3), expt.amplcalc);
+
         % clear screen
         delete_exptText(h_fig,h_text)
         clear h_text

--- a/experiment_helpers/run_measureFormants_audapter.m
+++ b/experiment_helpers/run_measureFormants_audapter.m
@@ -137,7 +137,7 @@ for itrial = 1:length(trials2run)  % for each trial
         delete_exptText(h_fig,h_text)
         clear h_text
 
-        if ~bGoodTrial && itrial > 9
+        if ~bGoodTrial && itrial > 1
             h_text = draw_exptText(h_fig,.5,.2,'Please speak a little louder','FontSize',40,'HorizontalAlignment','center','Color','y');
             pause(1)
             delete_exptText(h_fig,h_text)

--- a/experiment_helpers/run_measureFormants_audapter.m
+++ b/experiment_helpers/run_measureFormants_audapter.m
@@ -137,7 +137,7 @@ for itrial = 1:length(trials2run)  % for each trial
         delete_exptText(h_fig,h_text)
         clear h_text
 
-        if ~bGoodTrial
+        if ~bGoodTrial && itrial > 9
             h_text = draw_exptText(h_fig,.5,.2,'Please speak a little louder','FontSize',40,'HorizontalAlignment','center','Color','y');
             pause(1)
             delete_exptText(h_fig,h_text)


### PR DESCRIPTION
This is a replacement to #69 , which I kind of messed up by rebasing and not merging with master for 6 months.

@carrien , the new things are:

- Line 20 to initialize the empty struct properly
- lines 36-45 for the expt.amplcalc default params, now that #92 is merged
- lines 51-56 for correctly setting these fields
- Updated `run_measureFormants_audapter` to use the new expt.amplcalc fields

Original description:

> 
> This function can be called in contexts where the experiment-programmer wants to collect information about a participant's LPC order or default vowel space area in a pretest phase. Previously, this was achieved by similar or identical lines of code being used in many run_..._expt functions.
> 
> This function adds a few features rarely implemented in other experiments:
> * Asks the experimenter to verify that the recorded sample was good, rather than assuming it was good and moving on
> * Verifies that a file `nlpc.mat` was actually saved. (It might not be saved if the experimenter chooses "Exit without saving" from within the check_audapterLPC GUI.) If no file was saved, this function re-collects speech samples.
> 
> All of the parameters of `exptPre` in this function can be overwritten. The coder simply needs to set those fields in exptPre before calling `run_checkLPC`. For example:
> ```
> exptPre.words = {'bead' 'bad' 'booed' 'bod'};     % sets stimulus words
> exptPre.nblocks = 5;                              % sets number of repetitions of each word
> expt = run_checkLPC(expt, exptPre);
> ```
> 
> Other pull requests in the repos [current-studies](https://github.com/blab-lab/current-studies/pull/38) and [cerebellar-battery](https://github.com/blab-lab/cerebellar-battery/pull/5) depend on this pull request. They should be merged after this one.