### PR TITLE
bugfix for subset of trials

### DIFF
--- a/experiment_helpers/check_audio.m
+++ b/experiment_helpers/check_audio.m
@@ -223,7 +223,7 @@ function goToNextSet(src,evt)
         guidata(src,UserData);
         plotTrials(src)
     elseif trials2Go > 0
-        UserData.currTrials = UserData.trials2Track(UserData.trialIndex(1)):UserData.trials2Track(end);
+        UserData.currTrials = UserData.trials2Track(UserData.trialIndex(1):UserData.trialIndex(end));
         guidata(src,UserData);
         plotTrials(src)
     end


### PR DESCRIPTION
When you are looking at a subset of trials (e.g., only "buy" trials in an experiment with buy, guide, and buyYogurt trials), when you get to the last 10 trials to look at, it gives you all trials chronologically rather than just the subset of trials. This is because when you only have 10 trials left to go, you: 

1. go into elseif trial2Go > 0 
2. UserData.currTrials is then defined as the vector of trials from userData.trials2Track(UserData.trialIndex(1)) : the very last trial that you are going to check. So if you actually want to look at, say, 281 283 285 ... 299, it will give you instead, 281 282 283 284 285... 299. And then only display the first 10 (because you can only plot 10), i.e. trials 281 - 290. Notably at this point you go from only looking at (say) buyTrials to looking at all words. 
3. RA tries to use >>, because the last trial is 290 and not 300, but there are now 0 trials2Go so is treated as "end" 

The code works fine as-is when you are looking at all trials in an experiment, but what it should be defined as instead is the trials that you get from trialIndices(1):trialIndices(end). 

If you want to test, you can go into taimComp\sp475 (we're not using this participant)

```
load('expt.mat')
buyTrials = expt.inds.words.buy; 
check_audio([], buyTrials);
```
Use >> to get to end. Under original code, when you hit trials 241-268, words will all be "buy". >> will make the next set be 271:280 with mixed words. Under new code, you will advance to 271-300 with exclusively buy trials instead. 

