### PR TITLE
fix for using check_audio after MFA in waverunner

### DIFF
--- a/experiment_helpers/check_audio.m
+++ b/experiment_helpers/check_audio.m
@@ -58,7 +58,7 @@ else
             load(fullfile(dataPath,'trials',sortedFilenames{i}))
             fileNameParts = strsplit(sortedFilenames{i},'.');
             trialIndex = str2double(fileNameParts{1});
-            if ~isfield(trialparams,'event_params') || trialparams.event_params.is_good_trial
+            if ~isfield(trialparams,'event_params') || ~isfield(trialparams.event_params, 'is_good_trial') || trialparams.event_params.is_good_trial
                 UserData.dataVals(trialIndex).bExcl = 0;
             else
                 UserData.dataVals(trialIndex).bExcl = 1;

--- a/speech/waverunner.m
+++ b/speech/waverunner.m
@@ -192,6 +192,9 @@ for itrial = trials2track
                 [tg_user_event_times, tg_user_event_names] = get_uev_from_tg_mpraat(tgPath);
                 trialparams.event_params.user_event_times = [trialparams.event_params.user_event_times, tg_user_event_times];
                 trialparams.event_params.user_event_names = [trialparams.event_params.user_event_names, tg_user_event_names];
+                if ~isfield(trialparams.event_params, 'is_good_trial')
+                    trialparams.event_params.is_good_trial = 1; 
+                end
             end
         end
         


### PR DESCRIPTION
**Issue**: if you have run MFA on a dataset, when you run waverunner, it adds those events to trialparams.event_params. That in itself is fine, but it doesn't add anything else to event_params.  

The main problem is that, specifically, it does not add the field is_good_trial. If you try to run check_audio on the data again, it will error out on a trial.mat file that was only created during waverunner because check_audio runs this check:  

`if ~isfield(trialparams,'event_params') || trialparams.event_params.is_good_trial`

 In the trials with MFA info but nothing else, event_params is a field, but is_good_trial does not exist.  

**Both solutions have been implemented**: 

1. In waverunner, when it adds the event information from MFA, also check for if is_good_trial exists. If it doesn't, generate field and set to 0. 
2. In check_audio, also check for is_good_trial existing as a field before doing the dataVals assignment

