### PR TITLE
Change pause text

### DIFF
--- a/experiment_helpers/pause_trial.m
+++ b/experiment_helpers/pause_trial.m
@@ -3,12 +3,11 @@ function [] = pause_trial(h_fig,params)
 get_figinds_audapter;
 
 % text params
-% Addition for simonToneLex RK 2022-01-31
 if nargin < 2 || isempty(params)
     params = struct;
 end
-params = set_missingField(params, 'pausetxt', 'Paused. Press the space bar to continue.', 1);
-params = set_missingField(params, 'conttxt', 'We will now continue.', 1);
+params = set_missingField(params, 'pausetxt', 'Experiment paused. Please wait.', 1);
+params = set_missingField(params, 'conttxt', 'Experiment will now continue.', 1);
 pausetxt = params.pausetxt;
 conttxt = params.conttxt;
 

--- a/experiment_helpers/pause_trial.m
+++ b/experiment_helpers/pause_trial.m
@@ -6,6 +6,8 @@ get_figinds_audapter;
 if nargin < 2 || isempty(params)
     params = struct;
 end
+
+% if changing defaults, consider also changing free-speech\experiment_helpers\set_exptDefaults.m
 params = set_missingField(params, 'pausetxt', 'Experiment paused. Please wait.', 1);
 params = set_missingField(params, 'conttxt', 'Experiment will now continue.', 1);
 pausetxt = params.pausetxt;

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -150,6 +150,11 @@ expt = set_missingField(expt,'startBlock',ceil(expt.startTrial/expt.ntrials_per_
 expt = set_missingField(expt,'isRestart',0);
 expt = set_missingField(expt,'crashTrials',[]);
 
+%% pause parameters
+pauseParams.pausetxt = 'Experiment paused. Please wait.';
+pauseParams.conttxt  = 'Experiment will now continue.';
+expt = set_missingField(expt, 'pauseParams', pauseParams);
+
 %% trial indices
 
 expt.inds = get_exptInds(expt);

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -151,6 +151,7 @@ expt = set_missingField(expt,'isRestart',0);
 expt = set_missingField(expt,'crashTrials',[]);
 
 %% pause parameters
+% if changing these fields, consider also updating free-speech/experiment_helpers\pause_trial.m
 pauseParams.pausetxt = 'Experiment paused. Please wait.';
 pauseParams.conttxt  = 'Experiment will now continue.';
 expt = set_missingField(expt, 'pauseParams', pauseParams);


### PR DESCRIPTION
Change the text that shows up on screen when the participant pause so that it DOESN'T say how to unpause. The experimenter will either unpause or tell them when to do that.

This also adds a `pauseParams` field to `expt` via `set_exptDefaults`. The name of the field and sub-fields are aligned with previous experiments, notably simonToneLex, which changed `pause_trial` to add a params input argument.