### PR TITLE
`check_rmsThresh` use 2nd param; use peak

### DIFF
--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -18,8 +18,7 @@ function bGoodTrial = check_rmsThresh(data,params,subAxis)
 %              In check_rmsThresh, an area is shaded green between the low
 %              and hi Good limits, and an area is shaded yellow between Warn limits.
 %          * rmsThresh. If the RMS value is below rmsThresh, the output
-%              parameter bGoodTrial will be 0. This parameter is overridden by
-%              the 2nd input param `rmsThresh`, if that input param is used.
+%              parameter bGoodTrial will be 0.
 %       If `params` is a DOUBLE: params will be interpreted as
 %         the value of the field rmsThresh (see above).
 %   * subAxis. If a graphics object is included in the 3rd input parameter,

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -47,6 +47,7 @@ params = set_missingFields(params, defaultParams, 0);
 switch params.checkMethod
     case 'peak'
         [rmsValue, peak] = max(data.rms(:,1));
+        onset = peak;
         offset = peak;
     case 'peak_window'
         % onset and offset are some number of ms before and after the peak.

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -28,7 +28,7 @@ function bGoodTrial = check_rmsThresh(data,params,subAxis)
 %
 
 if nargin < 2
-    params.checkMethod = 'peak';
+    params = [];
 elseif isnumeric(params)
     rmsThresh = params;
     params = struct;

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -39,7 +39,7 @@ if nargin < 3, subAxis = []; end
 
 defaultParams.checkMethod = 'peak_window';
 defaultParams.limits = [0.037, 0.100; 0 0];
-defaultParams.peakWindowSecs = 0.2;
+defaultParams.peakWindowSecs = 0.1;
 defaultParams.rmsThresh = 0.037;
 params = set_missingFields(params, defaultParams, 0);
 

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -20,7 +20,7 @@ function bGoodTrial = check_rmsThresh(data,params,subAxis)
 %              and hi Good limits, and an area is shaded yellow between Warn limits.
 %          * rmsThresh. If the RMS value is below rmsThresh, the output
 %              parameter bGoodTrial will be 0.
-%          * peakWindowSecs. 
+%          * peakWindowSecs. Width of the window centered in the peak, in seconds.
 %       If `params` is a DOUBLE: params will be interpreted as
 %         the value of the field rmsThresh (see above).
 %   * subAxis. If a graphics object is included in the 3rd input parameter,
@@ -46,8 +46,8 @@ params = set_missingFields(params, defaultParams, 0);
 %% find rmsValue
 switch params.checkMethod
     case 'peak'
-        [rmsValue, onset] = max(data.rms(:,1));
-        offset = onset;
+        [rmsValue, peak] = max(data.rms(:,1));
+        offset = peak;
     case 'peak_window'
         % onset and offset are some number of ms before and after the peak.
         % rmsValue is the mean RMS between onset and offset.

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -10,8 +10,9 @@ function bGoodTrial = check_rmsThresh(data,params,subAxis)
 %   * params. Can be a struct (new format) or double (historical format).
 %       If `params` is a STRUCT: It can contain the following fields
 %         which affect the amplitude calculation:
-%           * checkMethod. If 'mean', the RMS value is calculated as the mean
-%              RMS during the vowel. If 'peak', the RMS value is the peak RMS.
+%           * checkMethod. If 'peak_window', the RMS value is the mean RMS
+%               during a period centered on the peak. If 'peak',
+%               the RMS value is the absolute peak RMS.
 %           * limits. A 2x2 array structured like this:
 %                  [GoodLow, GoodHi;
 %                   WarnLow, WarnHi]
@@ -35,7 +36,7 @@ elseif isnumeric(params)
 end
 if nargin < 3, subAxis = []; end
 
-defaultParams.checkMethod = 'mean';
+defaultParams.checkMethod = 'peak_window';
 defaultParams.limits = [0.037, 0.100; 0 0];
 defaultParams.peakBufferSecs = 0.1;
 defaultParams.rmsThresh = 0.037;
@@ -46,7 +47,7 @@ switch params.checkMethod
     case 'peak'
         [rmsValue, onset] = max(data.rms(:,1));
         offset = onset;
-    case 'mean'
+    case 'peak_window'
         % onset and offset are some number of ms before and after the peak.
         % rmsValue is the mean RMS between onset and offset.
         frameLenInSecs = data.params.frameLen/data.params.sRate;

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -56,12 +56,10 @@ switch params.checkMethod
         onset = peak-peakBufferNFrames;
         if onset < 1
             onset = 1;
-            fprintf('Yes onset\n')
         end
         offset = peak+peakBufferNFrames;
         if offset > length(data.rms)
             offset = length(data.rms);
-            fprintf('Yes offset\n')
         end
         rmsValue = mean(data.rms(onset:offset, 1));
 end % of switch/case

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -32,7 +32,7 @@ if nargin < 2
 elseif isnumeric(params)
     rmsThresh = params;
     params = struct;
-    params.checkMethod = 'peak';
+    params.checkMethod = 'peak'; % maintain legacy behavior
     params.rmsThresh = rmsThresh;
 end
 if nargin < 3, subAxis = []; end

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -54,7 +54,7 @@ switch params.checkMethod
         frameLenInSecs = data.params.frameLen/data.params.sRate;
         peakWindowNFrames = round(params.peakWindowSecs/frameLenInSecs);
         [~, peak] = max(data(1).rms(:, 1));
-        onset = peak - peakWindowNFrames/2;
+        onset = round(peak - peakWindowNFrames/2);
         if onset < 1
             onset = 1;
         end

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -20,6 +20,7 @@ function bGoodTrial = check_rmsThresh(data,params,subAxis)
 %              and hi Good limits, and an area is shaded yellow between Warn limits.
 %          * rmsThresh. If the RMS value is below rmsThresh, the output
 %              parameter bGoodTrial will be 0.
+%          * peakWindowSecs. 
 %       If `params` is a DOUBLE: params will be interpreted as
 %         the value of the field rmsThresh (see above).
 %   * subAxis. If a graphics object is included in the 3rd input parameter,
@@ -38,7 +39,7 @@ if nargin < 3, subAxis = []; end
 
 defaultParams.checkMethod = 'peak_window';
 defaultParams.limits = [0.037, 0.100; 0 0];
-defaultParams.peakBufferSecs = 0.1;
+defaultParams.peakWindowSecs = 0.2;
 defaultParams.rmsThresh = 0.037;
 params = set_missingFields(params, defaultParams, 0);
 
@@ -51,13 +52,13 @@ switch params.checkMethod
         % onset and offset are some number of ms before and after the peak.
         % rmsValue is the mean RMS between onset and offset.
         frameLenInSecs = data.params.frameLen/data.params.sRate;
-        peakBufferNFrames = round(params.peakBufferSecs/frameLenInSecs);
+        peakWindowNFrames = round(params.peakWindowSecs/frameLenInSecs);
         [~, peak] = max(data(1).rms(:, 1));
-        onset = peak-peakBufferNFrames;
+        onset = peak - peakWindowNFrames/2;
         if onset < 1
             onset = 1;
         end
-        offset = peak+peakBufferNFrames;
+        offset = peak + peakWindowNFrames/2;
         if offset > length(data.rms)
             offset = length(data.rms);
         end

--- a/experiment_helpers/check_rmsThresh.m
+++ b/experiment_helpers/check_rmsThresh.m
@@ -1,4 +1,4 @@
-function bGoodTrial = check_rmsThresh(data,inputArg2,subAxis)
+function bGoodTrial = check_rmsThresh(data,params,subAxis)
 % Takes a data file from Audapter and checks the amplitude of that signal
 % against certain parmeters. Primarily, it checks if the calculated
 % RMS value is above a certain threshold (rmsThresh). It also displays
@@ -7,11 +7,9 @@ function bGoodTrial = check_rmsThresh(data,inputArg2,subAxis)
 %
 % Input arguments:
 %   * data. The output data structure from Audapter
-%   * inputArg2. Can be a struct (new format) or double (historical format).
-%       If it's a DOUBLE: When the RMS value of data is below rmsThresh,
-%         the output parameter bGoodTrial will be 0.
-%       If it's a STRUCT: It controls parts of this function. Often stored
-%         in expt.amplcalc. Relevant fields:
+%   * params. Can be a struct (new format) or double (historical format).
+%       If `params` is a STRUCT: It can contain the following fields
+%         which affect the amplitude calculation:
 %           * checkMethod. If 'mean', the RMS value is calculated as the mean
 %              RMS during the vowel. If 'peak', the RMS value is the peak RMS.
 %           * limits. A 2x2 array structured like this:
@@ -21,29 +19,24 @@ function bGoodTrial = check_rmsThresh(data,inputArg2,subAxis)
 %              and hi Good limits, and an area is shaded yellow between Warn limits.
 %          * rmsThresh. If the RMS value is below rmsThresh, the output
 %              parameter bGoodTrial will be 0. This parameter is overridden by
-%               the 2nd input param `rmsThresh`, if that input param is used.
+%              the 2nd input param `rmsThresh`, if that input param is used.
+%       If `params` is a DOUBLE: params will be interpreted as
+%         the value of the field rmsThresh (see above).
 %   * subAxis. If a graphics object is included in the 3rd input parameter,
 %       the mean RMS and OST values are plotted.
-%   * params: A structure (often stored in expt.amplcalc)
-%       controlling parts of this function, with relevant fields:
-
-%
 %
 
 if nargin < 2
+    params.checkMethod = 'peak';
+elseif isnumeric(params)
+    rmsThresh = params;
     params = struct;
-    defaultParams.checkMethod = 'peak';
-else
-    if isstruct(inputArg2)
-        params = inputArg2;
-        defaultParams.checkMethod = 'mean';
-    else % do we want an elseif isnumeric(inputArg2)
-        params.rmsThresh = inputArg2;
-        defaultParams.checkMethod = 'peak';
-    end
+    params.checkMethod = 'peak';
+    params.rmsThresh = rmsThresh;
 end
 if nargin < 3, subAxis = []; end
 
+defaultParams.checkMethod = 'mean';
 defaultParams.limits = [0.037, 0.100; 0 0];
 defaultParams.rmsThresh = 0.037;
 params = set_missingFields(params, defaultParams, 0);

--- a/experiment_helpers/run_checkLPC.m
+++ b/experiment_helpers/run_checkLPC.m
@@ -33,8 +33,8 @@ if isfield(expt, 'bTestMode') && expt.bTestMode
 else
     defaultParams.nblocks = 10; % number of repetitions of each word
 end
-defaultParams.amplcalc.checkMethod = 'mean';
-defaultParams.amplcalc.rmsThresh = 0.03; % quite low amplitude required for "talk louder" message
+defaultParams.amplcalc.checkMethod = 'peak_window';
+defaultParams.amplcalc.rmsThresh = 0.037;
 % amplcalc.limits is a 2x2 array structured like this:
 %        [GoodLow, GoodHi;
 %         WarnLow, WarnHi]

--- a/experiment_helpers/run_measureFormants_audapter.m
+++ b/experiment_helpers/run_measureFormants_audapter.m
@@ -131,7 +131,7 @@ for itrial = 1:length(trials2run)  % for each trial
         data.bChangeOst = 0; 
 
         %plot amplitude and ost tracking
-        bGoodTrial = check_rmsThresh(data,[],h_sub(3), expt.amplcalc);
+        bGoodTrial = check_rmsThresh(data, expt.amplcalc, h_sub(3));
 
         % clear screen
         delete_exptText(h_fig,h_text)

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -125,7 +125,7 @@ expt = set_missingField(expt,'durcalc',durcalc);
 amplcalc.min_ampl = 0.04; %0.02;
 amplcalc.max_ampl = 0.24; %0.2;
 amplcalc.checkMethod = 'mean';   % Compare mean RMS during vowel against amplcalc.rmsThresh
-amplcalc.peakBufferSecs = 0.100; % Number of seconds of buffer to subtract/add from moment of peak amplitude to find onset/offset
+amplcalc.peakWindowSecs = 0.200; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware
     % expt.amplcalc.limits is a 2x2 array structured like this:
     %        [GoodLow, GoodHi;

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -130,7 +130,7 @@ amplcalc.offs_thresh = 0.015;
 
 % used with newer experiments
 amplcalc.checkMethod = 'peak_window';   % Compare mean RMS during vowel against amplcalc.rmsThresh
-amplcalc.peakWindowSecs = 0.200; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
+amplcalc.peakWindowSecs = 0.100; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware
     % expt.amplcalc.limits is a 2x2 array structured like this:
     %        [GoodLow, GoodHi;

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -129,7 +129,7 @@ amplcalc.ons_thresh = 0.01;
 amplcalc.offs_thresh = 0.015;
 
 % used with newer experiments
-amplcalc.checkMethod = 'mean';   % Compare mean RMS during vowel against amplcalc.rmsThresh
+amplcalc.checkMethod = 'peak_window';   % Compare mean RMS during vowel against amplcalc.rmsThresh
 amplcalc.peakWindowSecs = 0.200; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware
     % expt.amplcalc.limits is a 2x2 array structured like this:

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -124,6 +124,8 @@ expt = set_missingField(expt,'durcalc',durcalc);
 %% amplitude tracking parameters
 amplcalc.min_ampl = 0.04; %0.02;
 amplcalc.max_ampl = 0.24; %0.2;
+amplcalc.ons_thresh = 0.01;
+amplcalc.offs_thresh = 0.015;
 amplcalc.checkMethod = 'mean';   % Compare mean RMS during vowel against amplcalc.rmsThresh
 amplcalc.peakWindowSecs = 0.200; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -124,8 +124,6 @@ expt = set_missingField(expt,'durcalc',durcalc);
 %% amplitude tracking parameters
 amplcalc.min_ampl = 0.04; %0.02;
 amplcalc.max_ampl = 0.24; %0.2;
-amplcalc.ons_thresh = 0.01;
-amplcalc.offs_thresh = 0.015;
 amplcalc.checkMethod = 'mean';   % Compare mean RMS during vowel against amplcalc.rmsThresh
 amplcalc.peakBufferSecs = 0.100; % Number of seconds of buffer to subtract/add from moment of peak amplitude to find onset/offset
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -130,7 +130,7 @@ amplcalc.offs_thresh = 0.015;
 
 % used with newer experiments
 amplcalc.checkMethod = 'peak_window';   % Compare mean RMS during vowel against amplcalc.rmsThresh
-amplcalc.peakWindowSecs = 0.100; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
+amplcalc.peakWindowSecs = 0.100; % Size of window (in seconds) surrounding the peak amplitude to find RMS value
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware
     % expt.amplcalc.limits is a 2x2 array structured like this:
     %        [GoodLow, GoodHi;

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -127,6 +127,7 @@ amplcalc.max_ampl = 0.24; %0.2;
 amplcalc.ons_thresh = 0.01;
 amplcalc.offs_thresh = 0.015;
 amplcalc.checkMethod = 'mean';   % Compare mean RMS during vowel against amplcalc.rmsThresh
+amplcalc.peakBufferSecs = 0.100; % Number of seconds of buffer to subtract/add from moment of peak amplitude to find onset/offset
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware
     % expt.amplcalc.limits is a 2x2 array structured like this:
     %        [GoodLow, GoodHi;

--- a/experiment_helpers/set_exptDefaults.m
+++ b/experiment_helpers/set_exptDefaults.m
@@ -122,10 +122,13 @@ durcalc.bMeasureOst = 0;
 expt = set_missingField(expt,'durcalc',durcalc);
 
 %% amplitude tracking parameters
+%used with older experiments
 amplcalc.min_ampl = 0.04; %0.02;
 amplcalc.max_ampl = 0.24; %0.2;
 amplcalc.ons_thresh = 0.01;
 amplcalc.offs_thresh = 0.015;
+
+% used with newer experiments
 amplcalc.checkMethod = 'mean';   % Compare mean RMS during vowel against amplcalc.rmsThresh
 amplcalc.peakWindowSecs = 0.200; % Number of seconds of buffer to include surrounding the peak amplitude to find RMS value
 amplcalc.rmsThresh = 0.037;      % RMS values below this trigger "speak louder" prompt. 0.037 is ~78.5 dBA on SMNG hardware


### PR DESCRIPTION
Condense 2nd and 4th input params.

Get rid of the 'mean' method of calculating RMS value. Make a new method called 'peak_window'.

**This branch should not be merged immediately**. It should be timed with a change to current-studies which changes how input parameters are used for a small number of functions.