### PR TITLE
Update to add OST event names for simonPhrase

### DIFF
--- a/audapter_viewer/get_ostEventNamesNumbers.m
+++ b/audapter_viewer/get_ostEventNamesNumbers.m
@@ -122,6 +122,12 @@ elseif strcmp(trackingFileDir, 'simonMultisyllable_v2')
     eventNames = {'v1Start' 'v1End' 'v2Start' 'v2End'};
     triggerNo = get_pcf(trackingFileDir, trackingFileName, 'space', 4, 'stat');
     triggerName = eventNames{triggerNo == eventNos};
+
+% simonPhrase
+elseif strcmp(trackingFileDir, 'simonPhrase')
+    eventNames = {'v1Start' 'v1End' 'v2Start' 'v2End'};
+    triggerNo = get_pcf(trackingFileDir, trackingFileName, 'space', 4, 'stat');
+    triggerName = eventNames{triggerNo == eventNos};
     
 % timeWrap
 elseif strcmp(trackingFileDir, 'timeWrap')

--- a/audapter_viewer/get_ostEventNamesNumbers.m
+++ b/audapter_viewer/get_ostEventNamesNumbers.m
@@ -125,7 +125,7 @@ elseif strcmp(trackingFileDir, 'simonMultisyllable_v2')
 
 % simonPhrase
 elseif strcmp(trackingFileDir, 'simonPhrase')
-    eventNames = {'v1Start' 'v1End' 'v2Start' 'v2End'};
+    eventNames = {'v1Start' 'v1End'};
     triggerNo = get_pcf(trackingFileDir, trackingFileName, 'space', 4, 'stat');
     triggerName = eventNames{triggerNo == eventNos};
     


### PR DESCRIPTION
This is required for simonPhrase to call audapter_viewer properly. I created #114 to address the fact that `get_ostEventNamesNumbers` should probably work out-of-the-box for simon experiments, but in fact requires updates to not error out.