### PR TITLE
Add `drawnow` to plotting functions

### DIFF
--- a/experiment_helpers/calc_pertField.m
+++ b/experiment_helpers/calc_pertField.m
@@ -176,6 +176,8 @@ if bPlot
     
     xlabel(xlab);
     ylabel(ylab);
+
+    drawnow;
 end
 
 %% asign values to output variable (p)

--- a/experiment_helpers/plot_perturbations.m
+++ b/experiment_helpers/plot_perturbations.m
@@ -59,4 +59,6 @@ xlabel('F1 (mels)')
 ylabel('F2 (mels)')
 axis equal
 makeFig4Screen
+drawnow;
 
+end


### PR DESCRIPTION
These functions are used in experiments where VSA figures are plotted, then the user is asked to confirm that the figure looks correct. Previously, sometimes the figure would **not** actually appear, but the code would continue to the section where it prompts the user to confirm that the figure looks good. This is apparently [a known issue](https://www.mathworks.com/matlabcentral/answers/95752-why-does-pause-0-fail-to-update-the-figure-in-matlab-7-0-1-r14sp1) related to how Matlab uses the "event queue".

This PR fixes the issue by adding the call `drawnow` at the end of functions which plot a thing and are frequently called in the middle of another function.