### PR TITLE
check_audapterLPC median point & play audio button

### DIFF
--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -21,6 +21,8 @@ UserData.f =f;
 % global settings
 UserData.referenceMethod = referenceMethod;
 UserData.defaultSelected = defaultSelected;
+UserData.formantTrackVisibility = 'on';
+UserData.vowelBoundsVisibility = 'on';
 
 % load data
 UserData.dataPath = dataPath;
@@ -398,6 +400,7 @@ function updatePlots(src)
             color2plot = plotColors(v,:);
         end
         UserData.formantTracks.(vow) = plot(tAxis/UserData.data(trial2plot).params.sr,UserData.data(trial2plot).fmts(:,1:2), 'Color',color2plot,'LineWidth',3);
+        set(UserData.formantTracks.(vow),'Visible',UserData.formantTrackVisibility);
         
         %plot ost
         framedur = 1 / UserData.data(trial2plot).params.sr*UserData.data(trial2plot).params.frameLen; %get frame duration
@@ -421,6 +424,7 @@ function updatePlots(src)
             UserData.vowelBounds.(vow)(4) = vline(vowMidOffs*framedur,'c');
             set(UserData.vowelBounds.(vow)(3),'LineWidth',2)
             set(UserData.vowelBounds.(vow)(4),'LineWidth',2)
+            set(UserData.vowelBounds.(vow),'Visible',UserData.vowelBoundsVisibility);
         else    
             set(UserData.warnPanel,'HighlightColor','yellow');
             outstring = textwrap(UserData.warnText,sprintf("Missing OST trigger: trial %d of %s", trialInd, vow));
@@ -454,8 +458,10 @@ function toggleFormants(src,evt)
         for j = 1:length(UserData.formantTracks.(vow))
             if strcmp(UserData.formantTracks.(vow)(j).Visible,'on')
                 set(UserData.formantTracks.(vow)(j),'Visible','off')
+                UserData.formantTrackVisibility = 'off';
             else
                 set(UserData.formantTracks.(vow)(j),'Visible','on')
+                UserData.formantTrackVisibility = 'on';
             end
         end
     end
@@ -470,8 +476,10 @@ function toggleVowelBounds(src,evt)
         for j = 1:length(UserData.vowelBounds.(vow))
             if strcmp(UserData.vowelBounds.(vow)(j).Visible,'on')
                 set(UserData.vowelBounds.(vow)(j),'Visible','off')
+                UserData.vowelBoundsVisibility = 'off';
             else
                 set(UserData.vowelBounds.(vow)(j),'Visible','on')
+                UserData.vowelBoundsVisibility = 'on';
             end
         end
     end

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -7,7 +7,7 @@ function expt = check_audapterLPC(dataPath, params)
 %   directory
 
 if nargin < 1 || isempty(dataPath), dataPath = cd; end
-if nargin < 2 || isempyt(params), params = struct; end
+if nargin < 2 || isempty(params), params = struct; end
 
 defaultParams.refPointCalcMethod = 'mean';
 defaultParams.defaultPointSelected = 'far';

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -82,11 +82,10 @@ for i = 1:UserData.nVowels
 end
 
 %create panel for LPC info
-
 plotPanelXPos = 0.8+plotMargin;
 plotPanelXSpan = UserData.xPosMax-plotMargin/2-plotPanelXPos;
-plotPanelYSpan = 0.2 + plotMargin/2;
-plotPanelYPos = 0.75 - plotMargin/2 - plotPanelYSpan; 
+plotPanelYSpan = 0.15 + plotMargin/2;
+plotPanelYPos = 0.78 - plotMargin/2 - plotPanelYSpan; 
 
 plotPanelPos = [plotPanelXPos plotPanelYPos plotPanelXSpan plotPanelYSpan];
 UserData.lpcPanel = uipanel(UserData.f,'Units','Normalized','Position',...
@@ -99,8 +98,8 @@ UserData.nLPC = data(1).params.nLPC;
 
 xPos = 0.05;
 xSpan = 0.95 - xPos;
-yPos = 0.3;
-ySpan = 0.2;
+yPos = 0.25;
+ySpan = 0.25;
 LPCoptions = {'10','11','12','13','14','15','16','17','18','19','20'};
 UserData.LPCdrop = uicontrol(UserData.lpcPanel,...
     'Style','popupmenu',...
@@ -111,7 +110,7 @@ UserData.LPCdrop = uicontrol(UserData.lpcPanel,...
     'FontUnits','Normalized','FontSize',0.75,...
     'Callback',@changeLPC);
 
-yPos = 0.8;
+yPos = 0.65;
 UserData.LPCtext = uicontrol(UserData.lpcPanel,...
     'Style','text',...
     'Units','Normalized',...
@@ -132,6 +131,30 @@ UserData.warnText = uicontrol(UserData.warnPanel,'style','text',...
             'String',[],...
             'Units','Normalized','Position',[.1 .1 .8 .8],...
             'FontUnits','Normalized','FontSize',.3);
+
+%create panel for displaying reference point (mean vs median)
+xPos = 0.8+plotMargin;
+xSpan = UserData.xPosMax-plotMargin/2-xPos;
+yPos = 0.4;
+ySpan = 0.15;
+UserData.refPointPanel = uipanel(UserData.f,'Units','Normalized','Position',...
+            [xPos,yPos,xSpan,ySpan],...
+            'Tag','refPointPanel','Visible','on');
+
+UserData.refPointTextCtr = uicontrol(UserData.refPointPanel,'style','text',...
+            'String','Reference point',...
+            'Units','Normalized','Position',[.1 .65 .8 .25],...
+            'FontUnits','Normalized','FontSize',.75);
+
+refPointOptions = {'mean' 'median'};
+UserData.refPointCalcCtr = uicontrol(UserData.refPointPanel,...
+    'Style','popupmenu',...
+    'Units','Normalized',...
+    'Position',[.1, .25, .8, .30],...
+    'String',refPointOptions,...
+    'Value',find(strcmp(refPointOptions,UserData.refPointCalcMethod)),...
+    'FontUnits','Normalized','FontSize',0.75,...
+    'Callback',@updateReferenceMarker);
         
         
 %create OK button
@@ -147,22 +170,13 @@ UserData.hOK = uicontrol(UserData.f,'Style','pushbutton','String','OK',...
 %create change OSTs button (launches audapter_viewer)
 %yPos = 0.2+plotMargin/2;   
 %ySpan = 0.25 - plotMargin/2-yPos;
-yPos = 0.375 + plotMargin/2;
-ySpan = 0.475 - plotMargin/2 - yPos;
+yPos = 0.250 + plotMargin/2;
+ySpan = 0.350 - plotMargin/2 - yPos;
 UserData.toggle_formant = uicontrol(UserData.f,'Style','pushbutton',...
     'String','change OSTs',...
     'Units','Normalized','Position',[xPos,yPos,xSpan,ySpan],... 
     'FontUnits','Normalized','FontSize',0.35,...
     'Callback',@goto_audapter_viewer);
-
-%create toggle reference method button
-yPos = 0.300 + plotMargin/2;
-ySpan = 0.375 - plotMargin/2 - yPos;
-UserData.toggle_formant = uicontrol(UserData.f,'Style','pushbutton',...
-    'String','toggle mean/median',...
-    'Units','Normalized','Position',[xPos,yPos,xSpan,ySpan],... 
-    'FontUnits','Normalized','FontSize',0.35,...
-    'Callback',@updateReferenceMarker);
 
 %create toggle formants button
 UserData.toggle_formant = uicontrol(UserData.plotPanelTracks,'Style','pushbutton',...
@@ -186,7 +200,6 @@ UserData.toggle_formant = uicontrol(UserData.plotPanelF1F2,'Style','pushbutton',
     'Callback',@toggleIncludeData);
 
 %create play audio button
-% TODO change position to be next to "exclude/include trial" button
 UserData.toggle_formant = uicontrol(UserData.plotPanelF1F2,'Style','pushbutton',...
     'String','Play',...
     'Units','Normalized','Position',[.8 0 .15 .05],... 
@@ -222,7 +235,8 @@ function changeLPC(src,evt)
     %set warning
     set(UserData.warnPanel,'HighlightColor','yellow')
     outstring = textwrap(UserData.warnText,{'Loading data...'});
-    set(UserData.warnText,'String',outstring); pause(0.001) % without pause, message won't appear
+    set(UserData.warnText,'String',outstring);
+    drawnow;
 
     % set UserData.nLPC
     UserData.nLPC = str2double(cell2mat(UserData.LPCdrop.String(UserData.LPCdrop.Value)));
@@ -260,6 +274,7 @@ function changeLPC(src,evt)
     
     set(UserData.warnText,'String',[])
     set(UserData.warnPanel,'HighlightColor',[1 1 1])
+    drawnow;
 
 end
 
@@ -453,6 +468,7 @@ function updatePlots(src)
             set(UserData.warnPanel,'HighlightColor','yellow');
             outstring = textwrap(UserData.warnText,sprintf("Missing OST trigger: trial %d of %s", trialInd, vow));
             set(UserData.warnText,'String',outstring, 'FontSize', 0.25, 'Position', [0.05 0.05 .9 .9]);
+            drawnow;
         end
         title(vow,'FontUnits','normalized','FontSize',0.1)
         

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -178,9 +178,17 @@ UserData.toggle_formant = uicontrol(UserData.plotPanelTracks,'Style','pushbutton
 %create exclude data button
 UserData.toggle_formant = uicontrol(UserData.plotPanelF1F2,'Style','pushbutton',...
     'String','exclude/include trial',...
-    'Units','Normalized','Position',[.2 0 .6 .05],...
+    'Units','Normalized','Position',[0.25 0 .5 .05],...
     'FontUnits','Normalized','FontSize',0.5,...
     'Callback',@toggleIncludeData);
+
+%create play audio button
+% TODO change position to be next to "exclude/include trial" button
+UserData.toggle_formant = uicontrol(UserData.plotPanelF1F2,'Style','pushbutton',...
+    'String','Play',...
+    'Units','Normalized','Position',[.8 0 .15 .05],... 
+    'FontUnits','Normalized','FontSize',0.35,...
+    'Callback',@playSelectedTrial);
 
 
 guidata(f,UserData)
@@ -254,16 +262,29 @@ end
 
 function updateReferenceMarker(src, ~)
     UserData = guidata(src);
-    
     if strcmp(UserData.referenceMethod, 'mean')
         UserData.referenceMethod = 'median';
     else
         UserData.referenceMethod = 'mean';
     end
-    
+
     guidata(src,UserData)
     updatePlots(src)
+end
 
+function playSelectedTrial(src, ~)
+    UserData = guidata(src);
+    if isfield(UserData, 'selTrial')
+        vowels = fields(UserData.expt.inds.vowels);
+        vow = vowels{UserData.selTrial.vow};
+        iTrial = UserData.expt.inds.vowels.(vow)(UserData.selTrial.trial);
+        
+        y = UserData.data(iTrial).signalIn;
+        fs = UserData.data(iTrial).params.sRate;
+        sound(y, fs);
+    else
+        warndlg('Please select a trial')
+    end
 end
 
 function updatePlots(src)

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -6,6 +6,8 @@ function expt = check_audapterLPC(dataPath, params)
 %   dataPath: path where data.mat and expt.mat are. Default is current
 %   directory
 
+% TODO change output argument to be selectedTrials.(vowel) = trialnum 
+
 if nargin < 1 || isempty(dataPath), dataPath = cd; end
 if nargin < 2 || isempyt(params), params = struct; end
 
@@ -280,11 +282,8 @@ end
 
 function updateReferenceMarker(src, ~)
     UserData = guidata(src);
-    if strcmp(UserData.refPointCalcMethod, 'mean')
-        UserData.refPointCalcMethod = 'median';
-    else
-        UserData.refPointCalcMethod = 'mean';
-    end
+
+    UserData.refPointCalcMethod = cell2mat(UserData.refPointCalcCtr.String(UserData.refPointCalcCtr.Value));
 
     guidata(src,UserData)
     updatePlots(src)

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -1,4 +1,4 @@
-function expt = check_audapterLPC(dataPath, refPointCalcMethod, defaultPointSelected)
+function expt = check_audapterLPC(dataPath, params)
 % EXPT = CHECK_AUDAPTERLPC(dataPath)
 %Check that the LPC order used by Audapter is correctly tracking formants.
 %Update LPC order if needed. 
@@ -7,14 +7,11 @@ function expt = check_audapterLPC(dataPath, refPointCalcMethod, defaultPointSele
 %   directory
 
 if nargin < 1 || isempty(dataPath), dataPath = cd; end
-if nargin < 2 || isempty(refPointCalcMethod), refPointCalcMethod = 'mean'; end
-if nargin < 3 || isempty(defaultPointSelected)
-    if strcmp(refPointCalcMethod, 'median')
-        defaultPointSelected = 'near';
-    else % assumes 'mean' for refPointCalcMethod
-        defaultPointSelected = 'far';
-    end
-end
+if nargin < 2 || isempyt(params), params = struct; end
+
+defaultParams.refPointCalcMethod = 'mean';
+defaultParams.defaultPointSelected = 'far';
+params = set_missingFields(params, defaultParams, 0);
 
 %% create GUI
 f = figure('Visible','off','Units','Normalized','Position',[.05 .1 .9 .8]);
@@ -25,8 +22,8 @@ UserData = guihandles(f);
 UserData.f =f;
 
 % global settings
-UserData.refPointCalcMethod = refPointCalcMethod;
-UserData.defaultPointSelected = defaultPointSelected;
+UserData.refPointCalcMethod = params.refPointCalcMethod;
+UserData.defaultPointSelected = params.defaultPointSelected;
 UserData.formantTrackVisibility = 'on';
 UserData.vowelBoundsVisibility = 'on';
 

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -384,14 +384,14 @@ function updatePlots(src)
             dists = sqrt((currF1s-medianF1s).^2+(currF2s-medianF2s).^2);
             [~, trialInd] = min(dists);
             plusSignObj = plot(currF1s(trialInd),currF2s(trialInd),...
-                '+','MarkerEdgeColor',plotColors(v,:));
+                '+','MarkerEdgeColor',plotColors(v,:),'MarkerSize', 15);
             
             % save selected trial to expt
             exptTrialInd = goodTrials(trialInd);
             UserData.expt.selectedTrials.(vow) = exptTrialInd;
         else %assume mean
             plusSignObj = plot(mean(f1s(goodTrials), 'omitnan'),mean(f2s(goodTrials), 'omitnan'),...
-                '+','MarkerEdgeColor',plotColors(v,:));
+                '+','MarkerEdgeColor',plotColors(v,:),'MarkerSize', 15);
 
             % scrub selectedTrials (only used with median reference point)
             if isfield(UserData.expt, 'selectedTrials')

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -6,8 +6,6 @@ function expt = check_audapterLPC(dataPath, params)
 %   dataPath: path where data.mat and expt.mat are. Default is current
 %   directory
 
-% TODO change output argument to be selectedTrials.(vowel) = trialnum 
-
 if nargin < 1 || isempty(dataPath), dataPath = cd; end
 if nargin < 2 || isempyt(params), params = struct; end
 
@@ -387,9 +385,18 @@ function updatePlots(src)
             [~, trialInd] = min(dists);
             plusSignObj = plot(currF1s(trialInd),currF2s(trialInd),...
                 '+','MarkerEdgeColor',plotColors(v,:));
+            
+            % save selected trial to expt
+            exptTrialInd = goodTrials(trialInd);
+            UserData.expt.selectedTrials.(vow) = exptTrialInd;
         else %assume mean
             plusSignObj = plot(mean(f1s(goodTrials), 'omitnan'),mean(f2s(goodTrials), 'omitnan'),...
                 '+','MarkerEdgeColor',plotColors(v,:));
+
+            % scrub selectedTrials (only used with median reference point)
+            if isfield(UserData.expt, 'selectedTrials')
+                UserData.expt = rmfield(UserData.expt, 'selectedTrials');
+            end
         end
         uistack(plusSignObj, "bottom")
     end


### PR DESCRIPTION
Adds 2 features to the check_audapterLPC gui:

1. New "Reference point" selectable list which can switch between "mean" (default) and "median"
2. New "Play" button which plays audio for the selected trial

Other code changes:

3. Added a second input parameter "params" which controls (1.) mean vs median reference point at startup, and (2.) how the selected trials are picked at startup. For "mean" reference point, it's the trial furthest from the mean. For "median" reference point, it's the trial closest to the median.
4. Shifted several of the GUI buttons on the right panel to make room for "reference point" section
5. Previously, selecting a new trial (ie, clicking on a dot) would set the formants to "visible" and vowel bounds to "visible", even if the user had previously toggled them off. Now, the visibility status of formants and vowel bounds is not changed when the user selects a new trial.
6. The plus sign object (indicating the mean or median point for each vowel) was moved to the bottom of the stack of objects on the figure. This way, the user can select a dot even if it overlaps with a plus sign.

Showing the default behavior, where "mean" is the reference point
![image](https://github.com/carrien/free-speech/assets/50926971/dac411e8-a8f8-4917-b5cf-b6976b3cc0b1)

Showing the behavior when "median" is the reference point. And calls out the Play button. The plus sign indicating the median is hidden behind each of the selected points
![image](https://github.com/carrien/free-speech/assets/50926971/537ed7a1-795d-4159-93aa-8763414217f4)
