### PR TITLE
Update check_audioLevels.m

### DIFF
--- a/experiment_helpers/check_audioLevels.m
+++ b/experiment_helpers/check_audioLevels.m
@@ -13,7 +13,7 @@ get_figinds_audapter; % names figs: stim = 1, ctrl = 2, dup = 3;
 % close ctrl screen and enlarge experimenter's duplicated screen
 close(h_fig(ctrl)); 
 dup_position = [0 0.08 0.8 0.9]; %experimenter screen position
-set(h_fig(3),'OuterPosition',dup_position);
+set(h_fig(dup),'OuterPosition',dup_position);
 
 
 %% initialize Audapter 
@@ -55,7 +55,7 @@ switch what2check
         Audapter('stop');
 
     case 'b'
-        %% test headphone level
+        %% test headphone and mic levels
         Audapter('reset'); 
         Audapter('start'); 
         get_figinds_audapter;
@@ -63,7 +63,7 @@ switch what2check
         h_ready_dup = text(-0.4, 0.5, sprintf(['Testing mic amplitude.\n\n' ...
             'Set SPL meter to:\n\t\tNo max or min\n\t\tA mode\n\t\tSlow\n\t\tLevel 50-100 db\n\n' ...
             'Place SPL meter in headphones without foam cover.\n' ...
-            'Noise level should be ~80db while pp says "head".\n' ...
+            'Noise level should be ~80dB while pp says "head".\n' ...
             'If not, adjust microphone gain ("experiment mic").\n\n' ...
             'Press any key to stop.']), 'Color','white','FontSize',35);
         figure(h_fig(stim));

--- a/experiment_helpers/check_audioLevels.m
+++ b/experiment_helpers/check_audioLevels.m
@@ -1,13 +1,17 @@
 function check_audioLevels(what2check)
 if nargin < 1
-        what2check = questdlg({'do you want to check'; ...
-        '(a): that the mic and headphones are working, then check background noise levels (before participant arrives)';...
-        '(b): the microphone level with the participant'},'What do you want to check?','(a)','(b)','(a)');
+    what2check = 'a';
 end
 
 %% set up screens
 h_fig = setup_exptFigs;
 get_figinds_audapter; % names figs: stim = 1, ctrl = 2, dup = 3;
+
+% close ctrl screen and enlarge experimenter's duplicated screen
+close(h_fig(ctrl)); 
+dup_position = [0 0.08 0.8 0.9]; %experimenter screen position
+set(h_fig(3),'OuterPosition',dup_position);
+
 
 %% initialize Audapter 
 audioInterfaceName = 'Focusrite USB'; %SMNG default for Windows 10
@@ -33,49 +37,36 @@ AudapterIO('init', p);
 
 %% run test
 switch what2check
-    case '(a)'
-        %% test mic and headphones
-        % give instructions and wait for keypress
-        Audapter('reset'); 
-        Audapter('start'); 
-        h_ready = draw_exptText(h_fig,-.3,.5,{'Testing mic and headphones.';'Make sure you can hear your voice played back';'Press space to end test'},'Color','white','FontSize',35);
-        pause
-        Audapter('stop');
-        delete_exptText(h_fig,h_ready)
-        
+    case 'a'
         %% test headphone level
         Audapter('reset'); 
         Audapter('start'); 
-        h_ready = draw_exptText(h_fig,-.3,.5,sprintf(['Level testing has started.\n\n' ...
-            'Be sure headphones are plugged into output 2 of headphone amplifier.\n\n' ...
-            'Make sure SPL meter settings are:\n\t\tNo max or min\n\t\tA mode\n\t\tSlow\n\t\tLevel 50-100 db\n\n' ...
-            'Place SPL meter in headphones without foam cover.\n' ...
-            'Noise level should be ~60dB.\n' ...
-            'If levels are off, adjust "pp headphones" knob on headphone amplifier.\n\n' ...
-            'Press any key to stop once levels are confirmed.']),'Color','white','FontSize',35);
+        h_ready = draw_exptText(h_fig,-.4,.5,sprintf(['Testing mic and headphones.\n\n' ...
+            'Speak into mic. You should hear noise and speech in headphones.\n\n' ...
+            'Set SPL meter to:\n\t\tNo max or min\n\t\tA mode\n\t\tSlow\n\t\tLevel 50-100 db\n\n' ...
+            'Place SPL meter in headphones.\n' ...
+            'Noise level should be ~60dB\n' ...
+            'If not, adjust "pp headphones" knob on headphone amplifier.\n\n' ...
+            'Press any key to stop.']),'Color','white','FontSize',35);
         pause
         Audapter('stop');
-        delete_exptText(h_fig,h_ready)
 
-    case '(b)'
+    case 'b'
         %% test headphone level
         Audapter('reset'); 
         Audapter('start'); 
         get_figinds_audapter;
         figure(h_fig(dup));
-        h_ready_dup = text(-0.4, 0.5, sprintf(['Level testing has started.\n\n' ...
-            'Be sure headphones are plugged into output 2 of headphone amplifier.\n\n' ...
-            'Make sure SPL meter settings are:\n\t\tNo max or min\n\t\tA mode\n\t\tSlow\n\t\tLevel 50-100 db\n\n' ...
+        h_ready_dup = text(-0.4, 0.5, sprintf(['Testing mic amplitude.\n\n' ...
+            'Set SPL meter to:\n\t\tNo max or min\n\t\tA mode\n\t\tSlow\n\t\tLevel 50-100 db\n\n' ...
             'Place SPL meter in headphones without foam cover.\n' ...
             'Noise level should be ~80db while pp says "head".\n' ...
-            'Adjust the microphone gain ("experiment mic") if this is too low or too high.\n\n' ...
-            'Press any key to stop once levels are confirmed.']), 'Color','white','FontSize',35);
+            'If not, adjust microphone gain ("experiment mic").\n\n' ...
+            'Press any key to stop.']), 'Color','white','FontSize',35);
         figure(h_fig(stim));
         h_ready_stim = text(0, 0.5, sprintf('Please say "head" with the vowel stretched out \n                until the noise goes away.'), 'Color','white','FontSize',35);
         pause
         Audapter('stop');
-        delete_exptText(h_fig,h_ready_dup)
-        delete_exptText(h_fig,h_ready_stim)
 end
        
         %% clean up

--- a/experiment_helpers/check_audioLevels.m
+++ b/experiment_helpers/check_audioLevels.m
@@ -1,4 +1,7 @@
 function check_audioLevels(what2check)
+% Turns on Audapter in feedback mode 3 (speech + noise). Useful for testing
+% the amplitude of noise, and confirming that the mic and headphones work.
+
 if nargin < 1
     what2check = 'a';
 end


### PR DESCRIPTION
check_audioLevels historically had a "part A" (mode 'a') which was done before the participant arrives, and "part B" (mode b) which was done with the participant speaking. We no longer instruct experimenters to do part B. These code changes attempt to improve the usability of check_audioLevels, given that we only instruct experimenters to do part A.

Functional changes to this function:
- Assume input argument `what2check` has value `'a'` instead of asking via a dialogue box.
- In mode `'a'`, removed unnecessary 1st page of info that had redundant info with 2nd page. Now there is only 1 page of info and pressing any key once will end the script.

Aesthetic and "code improvement" changes:
- Make the figure on the experimenter's screen bigger so all text is legible from either screen
- Removed unnecessary `delete_exptText` calls, since we close all screens at the end of the script
- Change mode names from `('a')` and `('b')` to `'a'` and `'b'`
- Add header description
- Reworded several on-screen instructions to the experimenter for clarity and brevity