### PR TITLE
Fix MFA v3 system command input argument order

### DIFF
--- a/experiment_helpers/run_mfa.m
+++ b/experiment_helpers/run_mfa.m
@@ -170,7 +170,7 @@ switch params.version
         cd(params.dataPath);
 
         % Create the mfa command and then copy it to the clipboard so the user can paste it in
-        mfaCommand = sprintf('%s ./%s %s %s ./%s', 'mfa align --clean', 'PreAlignment', params.language, params.dictionary, 'PostAlignment');
+        mfaCommand = sprintf('%s ./%s %s %s ./%s', 'mfa align --clean', 'PreAlignment', params.dictionary, params.language, 'PostAlignment');
         clipboard('copy', mfaCommand);
         warning(sprintf(['The alignment command has been copied to your clipboard. \n' ...
             'When the CMD interface appears in the MATLAB Command Window, paste the command into the command window and hit enter.\n'...


### PR DESCRIPTION
The 'dictionary' and 'language' arguments in the MFA v3 system command were backwards. I realized this while testing a custom dictionary for vsaPD.

The system commands is correct in the part of this function which deals with MFA v1, so there's no need to edit that part of the code.