### PR TITLE
check_dataVals handle all NaNs trial

### DIFF
--- a/speech/check_dataVals.m
+++ b/speech/check_dataVals.m
@@ -236,6 +236,8 @@ function errors = get_dataVals_errors(UserData,dataVals)
         
         if dataVals(i).bExcl
             badTrials = [badTrials dataVals(i).token]; %#ok<*AGROW>
+        elseif bNaNVals % all values are NaNs 
+            nanFTrials = [nanFTrials dataVals(i).token];
         elseif dataVals(i).ampl_taxis(1) < .01 % check for speech starting too early--within 10 ms of start of recording
             earlyTrials = [earlyTrials dataVals(i).token];
         elseif dataVals(i).dur < UserData.errorParams.shortThresh %check for too short trials
@@ -486,7 +488,7 @@ function update_plots(src,evt)
             end
         end
     end
-    outstring = textwrap(UserData.warnText,{strcat(num2str(length(UserData.trialset)),' trials selected')});
+    outstring = textwrap(UserData.warnText,{strcat(num2str(length(UserData.trialset)),' trial(s) selected')});
     set(UserData.warnText,'String',outstring)
     guidata(src,UserData);
 end


### PR DESCRIPTION
Previously, if a trial has all NaNs as the formant values, check_dataVals would error. This situation could occur if there was a single user event after all tracked formants, like in the picture below. (Rare, but it happened once.)

![image](https://github.com/user-attachments/assets/8b9bea40-2a97-42aa-868e-5e6c83d0de14)

Now, that trial appears in the NaNFTrials category. It isn't plotted (there's nothing to plot), but the NaNFTrials button appears red, and the alert message will display "1 trial(s) selected."  I updated the check_dataVals KB page to explain this situation, since it's unusual to have an error trial that isn't plotted.

I also updated the alert message from "# trials selected" to "[#] trial(s) selected."