### PR TITLE
Counterbalancing updates

### DIFF
--- a/experiment_helpers/gen_cbPermutation.m
+++ b/experiment_helpers/gen_cbPermutation.m
@@ -1,9 +1,9 @@
-function [] = gen_cbPermutation(dataPath, exptName, conds, population)
+function [] = gen_cbPermutation(permSavePath, exptName, conds, population)
 %Generates a counterbalance tracking sheet for permutation combinations of
 %given conditions
 
-%dataPath: dataPath where counter balance tracking table will be saved
-    %Lab convention is to save this in SMNG/experiments/(exp_name)
+%permSavePath: directory path where counterbalance tracking table will be saved
+    %Lab convention is to save this in SMNG/experiments/(expt_name)
 %exptName: name of experiment
 %conds: what conditions are being counterbalanced
     %this could include words (e.g. {'bead', 'bad', 'bed'})
@@ -15,8 +15,8 @@ function [] = gen_cbPermutation(dataPath, exptName, conds, population)
 %population: name of separate populations (e.g. 'control' or 'clinical')
     %or you can use this field if you want separate tracking for groups (i.e. 'control' or 'perturbed') in the study
 %%
-if nargin <1 || isempty(dataPath)
-    dataPath = fullfile(get_exptLoadPath, exptName);
+if nargin <1 || isempty(permSavePath)
+    permSavePath = get_exptLoadPath(exptName);
 end
 
 [nRowsConds, ~] = size(conds);
@@ -33,10 +33,10 @@ else
 end
 
 %% check if permutation file already exists
-filename = strcat('cbPermutation_', exptName, populationStr, '.mat');
-permFile = fullfile(dataPath, filename); 
+permFileName = strcat('cbPermutation_', exptName, populationStr, '.mat');
+permFilePath = fullfile(permSavePath, permFileName);
 
-if isfile(permFile) 
+if isfile(permFilePath)
     bGenerate = askNChoiceQuestion('Are you sure you want to generate this permutation file? This will overwrite an existing file!'); 
 else 
     bGenerate = 'y';
@@ -51,14 +51,13 @@ if strcmp(bGenerate, 'y')
         permTable = perms(conds);
     end
 
-    % make column that will count the number of times a row is used
+    % add final column that will count the number of times a row is used
     [nRows, ~] = size(permTable);
     countList = num2cell(zeros(nRows, 1));
 
     %create table
-    permFile = horzcat(permTable, countList);
-    cbPermutation = permFile; %rename variable for saving
-    save(fullfile(dataPath, strcat('cbPermutation_', exptName, populationStr, '.mat')), 'cbPermutation');
+    cbPermutation = horzcat(permTable, countList);
+    save(permFilePath, 'cbPermutation');
 end
 
 end %EOF

--- a/experiment_helpers/get_cbPermutation.m
+++ b/experiment_helpers/get_cbPermutation.m
@@ -1,12 +1,12 @@
-function [permIx, permList, permLoadPath, permFileName] = get_cbPermutation(exptName, permLoadPath, population, permIx, allPermConds)
+function [permIx, permList, permSavePath, permFileName] = get_cbPermutation(exptName, permSavePath, population, permIx, allPermConds)
 % Gets counterbalancing permutation info for a participant. Also creates
 % the cbPermutation file if it doesn't exist yet.
 %
 % INPUT ARGUMENTS:
 % exptName: Normally the value in expt.name. simonTone, vsaRetention. Used
 %   to set permPath.
-% permLoadPath: The path of the folder from which you want to load the
-%   cbPermutation file.
+% permSavePath: The path to the folder which contains the cbPermutation
+%   file you want to use.
 % population: For studies where 'control' and 'patient', e.g., are tracked
 %   separately. The value of `population` should exactly match what's in
 %   the file name. So for "cbPermutation_patient.mat" the population is
@@ -23,7 +23,7 @@ function [permIx, permList, permLoadPath, permFileName] = get_cbPermutation(expt
 % OUTPUT ARGUMENTS:
 % permIx: Row number of cbPermutation used.
 % permList: Full set of conditions for that permutation.
-% permLoadPath: The path of the folder from which the cbPermutation
+% permSavePath: The path of the folder from which the cbPermutation
 %   file was loaded.
 % permFileName: The full name of the cbPermutation file loaded in.
 
@@ -35,7 +35,7 @@ function [permIx, permList, permLoadPath, permFileName] = get_cbPermutation(expt
 if nargin < 1 || isempty(exptName)
     error('Need exptName in input argument 1 for this function to run.')
 end
-if nargin < 2 || isempty(permLoadPath), permLoadPath = get_exptLoadPath(exptName); end  
+if nargin < 2 || isempty(permSavePath), permSavePath = get_exptLoadPath(exptName); end  
 if nargin < 3 || isempty(population)
     populationStr = '';
 else
@@ -50,32 +50,32 @@ end
 %% confirm filepath
 % if specified permPath isn't accessible (eg server offline), change
 % permPath to local default
-if ~exist(permLoadPath, 'dir')
+if ~exist(permSavePath, 'dir')
     permLoadPath_backup = get_exptLocalPath(exptName);
     if exist(permLoadPath_backup, 'dir')
-        warning('Couldn''t access cbPermutation loadPath at %s. Switching to this path instead: %s.', permLoadPath, permLoadPath_backup);
+        warning('Couldn''t access cbPermutation loadPath at %s. Switching to this path instead: %s.', permSavePath, permLoadPath_backup);
     else
-        error('Couldn''t access cbPermutation loadPath at %s. Backup load path at %s also did not exist.', permLoadPath, permLoadPath_backup);
+        error('Couldn''t access cbPermutation loadPath at %s. Backup load path at %s also did not exist.', permSavePath, permLoadPath_backup);
     end
-    permLoadPath = permLoadPath_backup;
+    permSavePath = permLoadPath_backup;
 end
 
-permFilePath = fullfile(permLoadPath, permFileName);
+permFilePath = fullfile(permSavePath, permFileName);
 
 % if permFile doesn't exist at permPath, try to make it
 if ~exist(permFilePath, 'file')
     if ~isempty(allPermConds)
-        warning('Since file %s was not found at %s, one was generated based on allPermConds.', permFileName, permLoadPath);
-        gen_cbPermutation(permLoadPath, exptName, allPermConds, population);
+        warning('Since file %s was not found at %s, one was generated based on allPermConds.', permFileName, permSavePath);
+        gen_cbPermutation(permSavePath, exptName, allPermConds, population);
     else
         error(['No file named %s exists at %s. Tried to generate that file, ' ...
-            'but allPermConds input arg was not set.'], permFileName, permLoadPath);
+            'but allPermConds input arg was not set.'], permFileName, permSavePath);
     end
 end
 
 %% retrieve info from cbPerm file
-perms = load(permFilePath); 
-varField = fieldnames(perms); 
+perms = load(permFilePath);
+varField = fieldnames(perms);
 cbPermutation = perms.(char(varField));
 
 % verify that the cbPerm file we're updating has the conditions we expect, based on allPermConds

--- a/experiment_helpers/set_cbPermutation.m
+++ b/experiment_helpers/set_cbPermutation.m
@@ -1,4 +1,4 @@
-function cbPermutation = set_cbPermutation(exptName, setRow, permPath, population, bSubtract)
+function cbPermutation = set_cbPermutation(exptName, setRow, permSavePath, population, bSubtract)
 % Increments the count column of a given row by one. Should be called after get_cbPermutation
 % It is possible to make this more flexible (see, for example, set_cbPermutation_timeAdapt) but for a standard
 % call in experiments there should be no reason to increase the count by more or less than one. 
@@ -7,12 +7,16 @@ function cbPermutation = set_cbPermutation(exptName, setRow, permPath, populatio
 % 
 % setRow: the index of the row you want to change. (This will be the output number from get_cbPermutation)
 % 
-% permPath: should be the same as your experiment path (top level) 
+% permSavePath: The folder which contains the cbPermutation file. Typically
+%               the same as your top level experiment path, i.e.,
+%               /smng/experiment/(expt_name)/
 % population: e.g. clinical, control. Use this if you have multiple populations and you're planning to counterbalance within
 % population rather than across the whole experiment
+%
+% bSubtract: Set to 1 to DEcrement a row of the cbPermutation file.
 % 
 
-if nargin < 3 || isempty(permPath), permPath = cd; end
+if nargin < 3 || isempty(permSavePath), permSavePath = cd; end
 if nargin < 4 || isempty(population)
     populationStr = '';
 else
@@ -20,13 +24,14 @@ else
 end
 if nargin < 5, bSubtract = 0; end
 
-permFile = strcat('cbPermutation_', exptName, populationStr, '.mat');
+permFileName = strcat('cbPermutation_', exptName, populationStr, '.mat');
+permFilePath = fullfile(permSavePath, permFileName);
 
-if ~exist(fullfile(permPath, permFile),'file')
-    error('Did not find a file called %s in directory %s\n', permFile, permPath); 
+if ~exist(permFilePath,'file')
+    error('Did not find a file called %s in directory %s\n', permFileName, permSavePath); 
 end
 
-perms = load(fullfile(permPath, permFile)); 
+perms = load(permFilePath); 
 varField = fieldnames(perms); 
 cbPermutation = perms.(char(varField));
 
@@ -39,6 +44,6 @@ elseif bSubtract == 1
 end
 cbPermutation{setRow,countCol} = newCount; 
 
-save(fullfile(permPath, permFile),'cbPermutation')
+save(permFilePath,'cbPermutation')
 
 end


### PR DESCRIPTION
### Formatting/refactoring changes to `gen_cbPermutation.m` and `set_cbPermutation.m`
Not discussed further.

### Functional changes to `get_cbPermutation.m`
* Add new input argument `allPermConds` (discussed later)
* Rewrite header
* Add a cascading series of if/else statements which generate the cbPermutation file if it doesn't exist, and tries to load from a local filepath if the file can't be found in the expected location. (Lines 50-74).
* * [Text description of that block of code] If the cbPermutation file doesn't exist at the specified path, instead of just erroring out, try to generate one using the `allPermConds` input argument. If that argument wasn't given or if the server isn't accessible at all, see if the cbPermutation file exists at the expected local path. If cbPermutation doesn't exist at the local path, make it if allPermConds was given. If allPermConds wasn't given, then error out. Descriptive warning and errors are printed whenever something doesn't go according to plan.
* Add new output arguments:
- - permLoadPath - where the cbPerm file was eventually loaded from
- - permFileName - the actual file name of the cbPermutation file, including the population suffix

### Merge timing
Should be merged simultaneously with the 'cbPerm-updates' branch of current-studies