### PR TITLE
add newlines in paths to fix TeX parsing

### DIFF
--- a/utils/savecheck.m
+++ b/utils/savecheck.m
@@ -17,6 +17,25 @@ if exist(savefile, ftype)
 
     colored_nameExt = sprintf('%s%s%s%s', '\color{blue}', name, extension, '\color{black}');
 
+    % To fix issue with `textwrap` in `questdlg` where TeX commands can be
+    % split across lines after 75 characters, proactively add some newlines
+    if length(path) > 75
+        new_path = '';
+        charCount = 0; % Counter to track characters since last newline
+
+        for i = 1:length(path)
+            new_path = [new_path, path(i)]; %#ok<AGROW> Append character
+            charCount = charCount + 1;
+
+            % If forward slash and near-ish the 75th character, add newline
+            if path(i) == '/' && charCount > 52
+                new_path = [new_path, newline]; %#ok<AGROW> Append newline
+                charCount = 0; % Reset character counter
+            end
+        end
+        path = new_path;
+    end
+
     % uses TeX formatting to change color and font size. See questdlg
     % documentation for help.
     messg = sprintf('%sThere is already a %s named %s here:\n\n%s\n\nDo you want to overwrite %s?', ...


### PR DESCRIPTION
We use TeX formatting when displaying the "are you sure you want to overwrite this file?" popup generated by `savecheck.m`. The question dialogue box `questdlg` is hardcoded to split up long strings, eg filepaths, into 75-character chunks which are then put into a cell array of character vectors. This chunking is done by `textwrap`. This chunking doesn't take into consideration TeX escape characters. So when the escape character is at the end of one char vector and the character that's supposed to be escaped is at the beginning of the next char vector, Java throws lots of errors and the text is not parsed properly.

![image](https://github.com/user-attachments/assets/d4183515-d72e-4e54-bb62-1399e78cb7bf)
![image](https://github.com/user-attachments/assets/379bcf8e-368f-433a-8137-755019438500)

Normally this problem presents itself when there is a filepath with an underscore, and the underscore just so happens to be the 75th (or 150th, etc) character in the file path. 

Now, `savecheck` will try to proactively break up long file paths by inserting a newline if it's getting close to the 75-character chunking limit. It will gracefully insert the newline at the start of a new directory name. 

![image](https://github.com/user-attachments/assets/bb66628b-0419-4011-93ff-f296df4ee587)

This doesn't completely solve the problem, but it should fix it in the vast majority of cases.  Completely solving the problem would involve either stopping using TeX entirely, making a copy of `questdlg` that doesn't hard code the `textwrap` chunking, or adding a lot more code to `savecheck` to look for TeX near the end of a line.