### PR TITLE
set backup trigger event name if none specified

### DIFF
--- a/audapter_viewer/get_ostEventNamesNumbers.m
+++ b/audapter_viewer/get_ostEventNamesNumbers.m
@@ -199,7 +199,11 @@ if ~exist('eventNames', 'var')
         eventNames{i} = ['ost' num2str(eventNos(i))];
     end
     triggerNo = get_pcf(trackingFileDir, trackingFileName, 'time', '1', 'ostStat_initial'); 
-    triggerName = eventNames{triggerNo == eventNos}; 
+    if ~isempty(triggerNo) % got a real trigger name from get_pcf
+        triggerName = eventNames{triggerNo == eventNos}; 
+    else % use backup event name
+        triggerName = eventNames{1};
+    end
 end
 
 


### PR DESCRIPTION
Fix to #114

In other words, previously, if you tried to run audapter_viewer on a dataset with a "space"-based shift where `get_ostEventNamesNumbers.m` didn't specify the shift names, get_ostEventNamesNumbers would error out because there was no "trigger" event name. (The trigger event is the primary OST event; typically when the perturbation turns on.)

Now, as a default/backup setting, get_ostEventNamesNumbers defaults to name the "trigger" event "ost2," and label the trigger event at OST==2.