### PR TITLE
Change to logic for picking which monitor an experiment-running figure displays on

### DIFF
--- a/experiment_helpers/setup_exptFigs.m
+++ b/experiment_helpers/setup_exptFigs.m
@@ -1,9 +1,9 @@
 function [h_fig] = setup_exptFigs()
 %SETUP_EXPTFIGS  Creates figures for experimenter and participant.
 %   SETUP_EXPTFIGS() creates and returns handles to figures for:
-%   (1) displaying stimuli to the participant (monitor 2)
-%   (2) displaying status and formant tracks for experimenter (monitor 1)
-%   (3) displaying a copy of the participant's view for experimenter (monitor 1)
+%   (1) displaying stimuli to the participant (second-from-the-left monitor)
+%   (2) displaying status and formant tracks for experimenter (leftmost monitor)
+%   (3) displaying a copy of the participant's view for experimenter (leftmost monitor)
 
 % set figure positions
 get_figinds_audapter;
@@ -15,11 +15,11 @@ pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking. Display
 pos{dup} = [0 0.3 0.6 0.7];    % duplicate of 'stim' for monitoring. Displays on experimenter's monitor.
 
 % Regardless of how the experimenter and participant's monitors are
-% PHYSICALLY positioned (left vs right), this code assumes that in Windows
+% PHYSICALLY positioned, this code assumes that in Windows
 % display settings, the experimenter's screen is virtually positioned to
-% the leftmost position, and the participant's screen is to the right of
+% the leftmost position, and the participant's screen is immediately to the right of
 % the experimenter's screen. The leftmost monitor's position will have the 
-% smallest x position value. That x coordinate value may be 1, or it may be
+% smallest x-coordinate value. That x coordinate value may be 1, or it may be
 % a negative number, depending on factors outside of your direct control.
 %
 % Each row in get(0, 'MonitorPositions') represents a monitor. Which row a
@@ -44,28 +44,11 @@ if nMonitors > 1
     % adjust each figure's position depending on which monitor it's
     % supposed to display on.
     exptMon_relativePos = round((exptMon_xCoord-1) / exptMon_xLength);
+    ppMon_relativePos   = round((ppMon_xCoord-1)   / ppMon_xLength);
+    pos{stim}(1) = pos{stim}(1) + ppMon_relativePos;
     pos{ctrl}(1) = pos{ctrl}(1) + exptMon_relativePos;
     pos{dup}(1)  = pos{dup}(1)  + exptMon_relativePos;
-
-    ppMon_relativePos = round((ppMon_xCoord-1) / ppMon_xLength);
-    pos{stim}(1) = pos{stim}(1) + ppMon_relativePos;
 end
-    
-
-%     monitor1_xCoordinate = monitorPositions(1,1);
-%     monitor2_xCoordinate = monitorPositions(2,1);
-%     mon2LeftOfMon1 = monitor2_xCoordinate < monitor1_xCoordinate;
-%     if mon2LeftOfMon1
-%         pos{stim} = [-1 0 1 1];         % participant view on left screen
-%     else
-%         pos{stim} = [1 0 1 1];         % participant view on right screen
-%     end
-% else %1 monitor setup
-%     pos{stim} = [1 0 1 1];
-% end
-% 
-% pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking
-% pos{dup} = [0 0.3 0.6 0.7];    % duplicate participant view for experimenter
 
 % define figure attributes
 figparams.Units = 'normalized';

--- a/experiment_helpers/setup_exptFigs.m
+++ b/experiment_helpers/setup_exptFigs.m
@@ -43,11 +43,11 @@ if nMonitors > 1
 
     % adjust each figure's position depending on which monitor it's
     % supposed to display on.
-    exptMon_relativePos = round(exptMon_xCoord-1 / exptMon_xLength);
+    exptMon_relativePos = round((exptMon_xCoord-1) / exptMon_xLength);
     pos{ctrl}(1) = pos{ctrl}(1) + exptMon_relativePos;
     pos{dup}(1)  = pos{dup}(1)  + exptMon_relativePos;
 
-    ppMon_relativePos = round(ppMon_xCoord-1 / ppMon_xLength);
+    ppMon_relativePos = round((ppMon_xCoord-1) / ppMon_xLength);
     pos{stim}(1) = pos{stim}(1) + ppMon_relativePos;
 end
     

--- a/experiment_helpers/setup_exptFigs.m
+++ b/experiment_helpers/setup_exptFigs.m
@@ -10,10 +10,18 @@ get_figinds_audapter;
 
 % check if 2nd monitor is to the right (pos. value) or left (neg. value) of main screen
 monitorPositions = get(0, 'MonitorPositions');
-if height(monitorPositions) > 1 && monitorPositions(2,1) < 0
-    pos{stim} = [-1 0 1 1];         % participant view on left screen
-else
-    pos{stim} = [1 0 1 1];         % participant view on right screen
+nMonitors = height(monitorPositions);
+if nMonitors > 1
+    monitor1_xCoordinate = monitorPositions(1,1);
+    monitor2_xCoordinate = monitorPositions(2,1);
+    mon2LeftOfMon1 = monitor2_xCoordinate < monitor1_xCoordinate;
+    if mon2LeftOfMon1
+        pos{stim} = [-1 0 1 1];         % participant view on left screen
+    else
+        pos{stim} = [1 0 1 1];         % participant view on right screen
+    end
+else %1 monitor setup
+    pos{stim} = [1 0 1 1];
 end
 
 pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking

--- a/experiment_helpers/setup_exptFigs.m
+++ b/experiment_helpers/setup_exptFigs.m
@@ -1,9 +1,9 @@
 function [h_fig] = setup_exptFigs()
 %SETUP_EXPTFIGS  Creates figures for experimenter and participant.
 %   SETUP_EXPTFIGS() creates and returns handles to figures for:
-%   (1) displaying stimuli to the participant (second-from-the-left monitor)
-%   (2) displaying status and formant tracks for experimenter (leftmost monitor)
-%   (3) displaying a copy of the participant's view for experimenter (leftmost monitor)
+%   (1) displaying stimuli to the participant (second-from-the-left screen in Windows display settings)
+%   (2) displaying status and formant tracks for experimenter (leftmost screen in Windows display settings)
+%   (3) displaying a copy of the participant's view for experimenter (leftmost screen in Windows display settings)
 
 % set figure positions
 get_figinds_audapter;
@@ -31,7 +31,7 @@ pos{dup} = [0 0.3 0.6 0.7];    % duplicate of 'stim' for monitoring. Displays on
 monitorPositions = get(0, 'MonitorPositions');
 nMonitors = height(monitorPositions);
 if nMonitors > 1
-    [~, sortedMonitorsIndices] = sort(monitorPositions);
+    [~, sortedMonitorsIndices] = sort(monitorPositions); % sorts rows from lowest to highest x coordinate value
 
     % get values for experimenter and participant monitors
     exptMon_ix = sortedMonitorsIndices(1);

--- a/experiment_helpers/setup_exptFigs.m
+++ b/experiment_helpers/setup_exptFigs.m
@@ -8,24 +8,64 @@ function [h_fig] = setup_exptFigs()
 % set figure positions
 get_figinds_audapter;
 
-% check if 2nd monitor is to the right (pos. value) or left (neg. value) of main screen
+% These are the baseline positions of each figure. The x position (first
+% value) is adjusted later once we know where the monitors are.
+pos{stim} = [0 0 1 1];         % stimulus presentation window. Displays on participant's monitor.
+pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking. Displays on experimenter's monitor.
+pos{dup} = [0 0.3 0.6 0.7];    % duplicate of 'stim' for monitoring. Displays on experimenter's monitor.
+
+% Regardless of how the experimenter and participant's monitors are
+% PHYSICALLY positioned (left vs right), this code assumes that in Windows
+% display settings, the experimenter's screen is virtually positioned to
+% the leftmost position, and the participant's screen is to the right of
+% the experimenter's screen. The leftmost monitor's position will have the 
+% smallest x position value. That x coordinate value may be 1, or it may be
+% a negative number, depending on factors outside of your direct control.
+%
+% Each row in get(0, 'MonitorPositions') represents a monitor. Which row a
+% monitor appears in is also outside of your direct control. Therefore, we
+% have to do a lookup of the x position to determine which indexed monitor
+% is the leftmost one. That will be set to the experimenter's monitor, and
+% the next monitor to the right will be the participant's monitor's index.
+
 monitorPositions = get(0, 'MonitorPositions');
 nMonitors = height(monitorPositions);
 if nMonitors > 1
-    monitor1_xCoordinate = monitorPositions(1,1);
-    monitor2_xCoordinate = monitorPositions(2,1);
-    mon2LeftOfMon1 = monitor2_xCoordinate < monitor1_xCoordinate;
-    if mon2LeftOfMon1
-        pos{stim} = [-1 0 1 1];         % participant view on left screen
-    else
-        pos{stim} = [1 0 1 1];         % participant view on right screen
-    end
-else %1 monitor setup
-    pos{stim} = [1 0 1 1];
-end
+    [~, sortedMonitorsIndices] = sort(monitorPositions);
 
-pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking
-pos{dup} = [0 0.3 0.6 0.7];    % duplicate participant view for experimenter
+    % get values for experimenter and participant monitors
+    exptMon_ix = sortedMonitorsIndices(1);
+    exptMon_xCoord = monitorPositions(exptMon_ix, 1);
+    exptMon_xLength = monitorPositions(exptMon_ix, 3);
+    ppMon_ix = sortedMonitorsIndices(2);
+    ppMon_xCoord = monitorPositions(ppMon_ix, 1);
+    ppMon_xLength = monitorPositions(ppMon_ix, 3);
+
+    % adjust each figure's position depending on which monitor it's
+    % supposed to display on.
+    exptMon_relativePos = round(exptMon_xCoord-1 / exptMon_xLength);
+    pos{ctrl}(1) = pos{ctrl}(1) + exptMon_relativePos;
+    pos{dup}(1)  = pos{dup}(1)  + exptMon_relativePos;
+
+    ppMon_relativePos = round(ppMon_xCoord-1 / ppMon_xLength);
+    pos{stim}(1) = pos{stim}(1) + ppMon_relativePos;
+end
+    
+
+%     monitor1_xCoordinate = monitorPositions(1,1);
+%     monitor2_xCoordinate = monitorPositions(2,1);
+%     mon2LeftOfMon1 = monitor2_xCoordinate < monitor1_xCoordinate;
+%     if mon2LeftOfMon1
+%         pos{stim} = [-1 0 1 1];         % participant view on left screen
+%     else
+%         pos{stim} = [1 0 1 1];         % participant view on right screen
+%     end
+% else %1 monitor setup
+%     pos{stim} = [1 0 1 1];
+% end
+% 
+% pos{ctrl} = [0.6 0.2 0.4 0.8]; % experimenter view and formant tracking
+% pos{dup} = [0 0.3 0.6 0.7];    % duplicate participant view for experimenter
 
 % define figure attributes
 figparams.Units = 'normalized';


### PR DESCRIPTION
All changes to `setup_exptFigs`

### How MATLAB screen numbers work
You can view MATLAB's screen information with `get(0, 'monitorPositions'). It tells you how many monitors MATLAB thinks you have, and what indexed ordered MATLAB puts them in. The order is often but not always from leftmost to rightmost. You do not have control over what indexed number MATLAB assigns to a monitor. The "MATLAB" indices of monitors does not always match up with the indices of monitors in Windows display settings. What this means is that, when you start MATLAB, you don't know for sure which physical monitor is considered by MATLAB to be "monitor 1". 

### How to deal with this situation
There are three options:
1. Assume that MATLAB isn't going to randomly change or flip flop how it determines which monitor is which, and assume that the "main display" in Windows display settings will be assigned monitor 1 in MATLAB. This is basically how `setup_exptFigs` worked previously.
2. Each time before using setup_exptFigs (any time running an experiment), ask the user which monitor is which via some MATLAB function. eg, it displays a 1 on monitor 1 and a 2 on monitor 2, then asks, "which one is the main monitor: 1 or 2?"
3. Require the user to position the experimenter screen to the left of participant's screen in Windows display settings. (We already do this in room 544 and did this in room 415 until recently.) Then the code can safely assume that the **leftmost** monitor is the experimenter's screen, no matter what index is associated with that monitor. The code in this pull request uses this solution.

If another lab using free-speech wants their experimenter screen on the right instead of the left, all they have to do is flip the values in lines 37 and 40 from 1 and 2, to 2 and 1.