### PR TITLE
dataPaths converted to char array if needed

### DIFF
--- a/audapter_viewer/choosePathDialog.m
+++ b/audapter_viewer/choosePathDialog.m
@@ -7,7 +7,7 @@ function pathChoice = choosePathDialog(possiblePaths, bServer)
 % Basic use of this is server version vs. experiment computer version of paths. 
 % 
 % Inputs: 
-% 1. possiblePaths: cell array of possible paths, e.g.
+% 1. possiblePaths: cell array containing char arrays of possible paths, e.g.
 % {'\\wcs-cifs.waisman.wisc.edu\wc\smng\experiments\timeAdapt\sp001\capper'
 % 'C:\Users\Public\Documents\experiments\timeAdapt\sp001\capper'}
 % --- defaults to current working directory 
@@ -28,6 +28,15 @@ pathChoice = 0; % default is 0, functioning essentially as cancel
 % If you have only one path for some reason, make sure it is a cell 
 if ~iscell(possiblePaths)
     possiblePaths = {possiblePaths}; 
+end
+
+% if any cells in possiblePaths aren't a character array (e.g., maybe it's 
+% a string array instead), make it a character array. The `contains`
+% operation below requires they all be the same type.
+for i = 1:length(possiblePaths)
+    if ~ischar(possiblePaths{i})
+        possiblePaths(i) = {char(possiblePaths{i})};
+    end
 end
 
 if nargin < 2 || isempty(bServer) || ~bServer


### PR DESCRIPTION
The possiblePaths variable in `choosePathDialog` can now support a mix of string arrays and char arrays instead of exclusively supporting char arrays. This came up because expt.dataPath for simonL2 is actually a string array, due to Yuyu putting double quotes around 1_BeforeProduction in the run_..._expt function
```
expt.dataPath = get_acoustSavePath(expt.name, expt.language, expt.snum, "1_BeforeProduction");
```

The check_audapterLPC phase of the experiment is when the experimenter can change LPC, include/exclude trials, and if necessary pop into audapter_viewer to adjust the OST settings that determine vowel onset/offset. Today I had a participant with significant prevoicing of vowels, such that using audapter_viewer to adjust OSTs was necessary to find the correct vowel onset. When saving out of the audapter_viewer GUI, L581-586 of `audapter_viewer` figure out where the updated data.mat file might need to be saved.
```
dataPathParts = strsplit(x.dataPath, 'experiments'); 
if length(dataPathParts) > 1 % assumes you're using default SMNG filepath structures and might access SMNG server
    serverPrefix = '\\wcs-cifs.waisman.wisc.edu\wc\smng\'; 
    serverPath = fullfile(serverPrefix, 'experiments', dataPathParts{2}); 
    isOnServer = exist(serverPath,'dir'); 
    savePath = choosePathDialog({serverPath, x.dataPath, pwd}, isOnServer); 
```
In the last line of the above code chunk, `choosePathDialog` is a audapter_viewer-specific function that tries to pick the correct savepath. If the data exists on the server, you're probably trying to update that one as the "real" datapath. If the server data doesn't exist, check the local path, then check the current directory as a fallback. Anyway, choosePathDialog assumes that the first input argument is a cell array of character arrays. If x.dataPath in audapter_viewer L586 is actually a string and not a char array, as is the case for simonL2, choosePathDialog breaks when performing the `contains` operation in old line 35.

The fix I implemented in this PR is to convert any strings to char arrays that were inputted to choosePathDialog.

I tested this change with simonL2 (now it works) and with an existing function that had a char array in expt.dataPath (it still works).