### PR TITLE
set bCopyParams only if event_params exists

### DIFF
--- a/speech/waverunner.m
+++ b/speech/waverunner.m
@@ -73,7 +73,7 @@ for itrial = trials2track
     % if trial data exists, load it
     savefile = fullfile(dataPath,trialfolder,sprintf('%d.mat',itrial));
     if (exist(savefile,'file') == 2)
-        bCopyParams = 0;
+        bCopyEventParams = 0;
         saveddata = load(savefile);
         trialparams = saveddata.trialparams;        % load saved trial params
         if isfield(trialparams,'sigproc_params')      % if sigproc_params exists, use existing values
@@ -110,7 +110,7 @@ for itrial = trials2track
             offsetMs = lags(imax)/data(itrial).params.sr;
             
             if isfield(trialparams,'event_params')      % if event_params exists, copy them
-                bCopyParams = 1;
+                bCopyEventParams = 1;
                 fieldns = fieldnames(trialparams.event_params);
                 for i=1:length(fieldns)                     % use previously saved params
                     if ~sum(strcmp(fieldns{i},params2overwrite))
@@ -121,7 +121,7 @@ for itrial = trials2track
                     end
                 end
             else
-                bCopyParams = 0;
+                bCopyEventParams = 0;
             end
         end
     else clear sigmat trialparams
@@ -173,7 +173,7 @@ for itrial = trials2track
         end
         trialparams.sigproc_params = sigproc_params;    % only overwrite sigproc_params (leave event/plot_params if they exist)
         
-        if exist('bCopyParams','var') && bCopyParams == 1 %overwrite event_params if copying from signalIn to signalOut
+        if exist('bCopyEventParams','var') && bCopyEventParams == 1 %overwrite event_params if copying from signalIn to signalOut
             trialparams.event_params = event_params;
         end
         

--- a/speech/waverunner.m
+++ b/speech/waverunner.m
@@ -86,7 +86,6 @@ for itrial = trials2track
         end
     elseif ~strcmp(buffertype,'signalIn')
         if exist(fullfile(dataPath,trialfolderSigIn,sprintf('%d.mat',itrial)),'file') && ~exist(fullfile(dataPath,trialfolder,sprintf('%d.mat',itrial)),'file')
-            bCopyParams = 1;
             copyfile = fullfile(dataPath,trialfolderSigIn,sprintf('%d.mat',itrial));
             saveddata = load(copyfile);
             trialparams = saveddata.trialparams;        % load saved trial params
@@ -111,6 +110,7 @@ for itrial = trials2track
             offsetMs = lags(imax)/data(itrial).params.sr;
             
             if isfield(trialparams,'event_params')      % if event_params exists, copy them
+                bCopyParams = 1;
                 fieldns = fieldnames(trialparams.event_params);
                 for i=1:length(fieldns)                     % use previously saved params
                     if ~sum(strcmp(fieldns{i},params2overwrite))
@@ -120,9 +120,9 @@ for itrial = trials2track
                         end
                     end
                 end
+            else
+                bCopyParams = 0;
             end
-        else
-            bCopyParams = 0;
         end
     else clear sigmat trialparams
     end


### PR DESCRIPTION
### Background and fix
When running `waverunner`, if you select a buffertype other than signalIn (e.g., if you choose signalOut), it will check if there are event_params (e.g., user events) on the signalIn version of the trial files. If there are, when it generates the trials_signalOut folder and signalOut trial files, it will copy over event_params from trials to trials_signalOut.

waverunner uses the faux boolean `bCopyParams` to keep track of whether it should try to copy over event_params or not. Previously, bCopyParams was set to 1 if the signalIn trial file existed (e.g., if 1.mat exists). Now, it sets bCopyParams to 1 if the trial file has a field called event_params (e.g., if 1.mat contains trialparams.event_params).

### When does this come up
In the "normal" fully clean workflow, where someone:
1. runs waverunner on signalIn
2. looks at each signalIn trial in audioGUI
3. runs waverunner to generate signalOut

... this situation will not come up. That's because when you load in a file in audioGUI (step #2 above), it ALWAYS creates a field trialparams.event_params. The issue comes up if you're doing the quick n' dirty data analysis:
1. run waverunner on signalIn
2. look at SOME but NOT ALL trials in audioGUI
3. run waverunner on signalOut
... in this situation, all trial files exist for signalIn data, but some don't have an event_params field.

### Testing
Tested with noGoAdaptPlayback pilot data that was done with the quick n' dirty method (which is where we were seeing the issue in the first place), and with existing data that had followed the clean workflow. 

Note that we don't currently have any experiments where we are generating signalOut data folders as part of the standard data analysis workflow anyway.