### PR TITLE
Select one PTB mic; respect PTB screen number selection

### DIFF
--- a/jnd/run_staircase_ptb.m
+++ b/jnd/run_staircase_ptb.m
@@ -8,10 +8,14 @@ save(fullfile(expt.dataPath, 'expt.mat'), 'expt');
 
 %% Set up peripherals (screens, audio device) 
 
-% Choose display (highest dislay number is a good guess)
 Screen('Preference', 'SkipSyncTests', 1);
 screens=Screen('Screens');
-screenNumber=max(screens);
+% determine screen number (default to highest available value)
+if isfield(expt, 'ptb_screenNum') && ~isempty(expt.ptb_screenNum)
+    screenNumber = expt.ptb_screenNum;
+else
+    screenNumber = max(screens);
+end
 if ~isfield(expt, 'win') % Should also check that the window actually exists
     win = Screen('OpenWindow', screenNumber);
     expt.win = win; 
@@ -26,6 +30,13 @@ deviceNames = {wasapiDevices.DeviceName};
 scarletts = find(contains(deviceNames, 'Focusrite')); 
 outputDevs = find([wasapiDevices.NrOutputChannels] > 0); 
 outputScarlett = intersect(outputDevs, scarletts); 
+
+if length(outputScarlett) > 1
+    outputScarlett = outputScarlett(1);
+    fprintf(['When deciding what output device to use, multiple plausible ' ...
+        'output devices were identified. I''ll pick the first one: %s'], ...
+        wasapiDevices(outputScarlett).DeviceName);
+end
 
 % Parameters for audio output 
 paMode = 1;              % only audio playback


### PR DESCRIPTION
This change fixes two potential problems when using Psychtoolbox for (1) stimulus display, and (2) audio recording or playback

### Set screen number using experimenter-defined value
Previously, for displaying Psychtoolbox stimuli, we hard-coded the stimulus presentation screen number as the highest-numbered screen as defined by Psychtoolbox with `Screen('Screens')`. Now, instead, we look for a value in expt.ptb_screenNum to define the screen number. The old method can be used as a fallback if that expt field isn't defined. (Correspondingly, we now define that expt field using the free-speech utils function `get_ptb_screenNum` in our run_..._expt functions.)
```
screens=Screen('Screens');
% determine screen number (default to highest available value)
if isfield(expt, 'ptb_screenNum') && ~isempty(expt.ptb_screenNum)
    screenNumber = expt.ptb_screenNum;
else
    screenNumber = max(screens);
end
```

### Pick only one input/output device
When using Psychportaudio, our previous method of picking a microphone or speaker sometimes gave us multiple plausible device IDs, and the script would error because it assumed there was only one plausible device ID. Now, if there are multiple, we tell the user that there were multiple, we tell the user which one was picked, and only one is selected for continuing the script.

We've seen this happen in practice with Focusrite microphones having a "Loopback" device which we don't want to use. This is always listed after the real "Analogue 1 + 2" device.

```
if length(outputScarlett) > 1
    outputScarlett = outputScarlett(1);
    fprintf(['When deciding what output device to use, multiple plausible ' ...
        'output devices were identified. I''ll pick the first one: %s'], ...
        wasapiDevices(outputScarlett).DeviceName);
end
```

<img width="515" height="151" alt="image" src="https://github.com/user-attachments/assets/f8c506ad-fc77-40ad-a991-361944f4640d" />
