### PR TITLE
Remove NaNs from list of trial numbers

### DIFF
--- a/utils/get_sortedTrials.m
+++ b/utils/get_sortedTrials.m
@@ -12,6 +12,10 @@ for i = 1:length(matFiles)
 end
 [sortedTrialnums,idx] = sort(filenums);
 
+% remove NaNs
+idx = idx(~isnan(sortedTrialnums));
+sortedTrialnums = sortedTrialnums(~isnan(sortedTrialnums));
+
 % Sort filenames in the same order
 sortedFilenames = matFiles(idx);
 


### PR DESCRIPTION
Fixes #170 

Filter out NaN entries from sortedTrialnums and the corresponding idx so filenames are ordered only by valid numeric trial numbers. This prevents NaN values from affecting the index used to sort matFiles.

I tested this with a few experiments, including vsaRetention, which was a good test because it has non-sequential trial numbers for the trials folder containing only transfer words (1-16, 51-100, etc.). 