### PR TITLE
replace vline/hline with xline/yline

### DIFF
--- a/experiment_helpers/calc_vowelMeans.m
+++ b/experiment_helpers/calc_vowelMeans.m
@@ -59,8 +59,8 @@ for itrial = trials2analyze
     end
     if bTest
         plot(data(itrial).fmts)
-        vline(vowelFrames(1),'k');
-        vline(vowelFrames(end),'k');
+        xline(vowelFrames(1),'Color','k');
+        xline(vowelFrames(end),'Color','k');
         pause
     end
 end

--- a/experiment_helpers/check_audapterLPC.m
+++ b/experiment_helpers/check_audapterLPC.m
@@ -463,12 +463,10 @@ function updatePlots(src)
             vowLength = length(vowelFrames);
             vowMidOns = floor(vowMidPoint-vowLength/4);
             vowMidOffs = floor(vowMidPoint+vowLength/4);
-            UserData.vowelBounds.(vow)(1) = vline(vowelFrames(1)*framedur,'k');
-            UserData.vowelBounds.(vow)(2) = vline(vowelFrames(end)*framedur,'k');
-            UserData.vowelBounds.(vow)(3) = vline(vowMidOns*framedur,'c');
-            UserData.vowelBounds.(vow)(4) = vline(vowMidOffs*framedur,'c');
-            set(UserData.vowelBounds.(vow)(3),'LineWidth',2)
-            set(UserData.vowelBounds.(vow)(4),'LineWidth',2)
+            UserData.vowelBounds.(vow)(1) = xline(vowelFrames(1)*framedur,'Color','k');
+            UserData.vowelBounds.(vow)(2) = xline(vowelFrames(end)*framedur,'Color','k');
+            UserData.vowelBounds.(vow)(3) = xline(vowMidOns*framedur,'Color','c','LineWidth',2);
+            UserData.vowelBounds.(vow)(4) = xline(vowMidOffs*framedur,'Color','c','LineWidth',2);
             set(UserData.vowelBounds.(vow),'Visible',UserData.vowelBoundsVisibility);
         else    
             set(UserData.warnPanel,'HighlightColor','yellow');

--- a/plotting/hline.m
+++ b/plotting/hline.m
@@ -1,6 +1,15 @@
 function hl = hline(val,color,linestyle,ax)
 % function hl = hline(val,color,linestyle,ax)
 
+% This function draws a horizontal line extending to the axis left and
+% right limits at runtime. Note that if the axis left-right limits are
+% changed later, the line will retain its original limits.
+%
+% If you instead want a horizontal line that extends infinitely left and
+% right, use the MATLAB built-in function YLINE. Note that YLINE creates a
+% LineConstant type object, whereas HLINE creates a Line type object, so
+% some object properties may have different names.
+
 if nargin < 4, ax = gca; end
 
 a = axis(ax);
@@ -12,3 +21,5 @@ end
 if nargin >= 3
   set(hl,'LineStyle',linestyle);
 end
+
+end %EOF

--- a/plotting/plot_adaptationTrack.m
+++ b/plotting/plot_adaptationTrack.m
@@ -27,10 +27,10 @@ end
 
 % get expt phase info
 load(fullfile(dataPath,'expt.mat'),'expt'); % load from last subject
-vlines(1) = expt.nBaseline;
-vlines(2) = vlines(1) + expt.nRamp;
-vlines(3) = vlines(2) + expt.nHold;
-vlines(4) = vlines(3) + expt.nPost;
+xlines(1) = expt.nBaseline;
+xlines(2) = xlines(1) + expt.nRamp;
+xlines(3) = xlines(2) + expt.nHold;
+xlines(4) = xlines(3) + expt.nPost;
 
 toBin = fieldnames(normavg); % different bin sizes
 for b = 1:length(toBin)
@@ -48,10 +48,10 @@ for i=1:length(toPlot)
     figure('Name',sprintf('%s all',figname))
     plot(allSubjNorm.allTrials.(figname),'.','Color',plotcolor)
     % draw lines to separate experiment phases
-    for v=1:length(vlines)
-        vline(vlines(v));
+    for v=1:length(xlines)
+        xline(xlines(v));
     end
-    hline(0);
+    yline(0);
     axis tight
     title(figname)
     
@@ -61,10 +61,10 @@ for i=1:length(toPlot)
         figure('Name',binfigname)
         plot(allSubjNorm.bins.(figname),'o','Color',plotcolor)
         % draw lines to separate experiment phases
-        for v=1:length(vlines)
-            vline(vlines(v)/binsize);
+        for v=1:length(xlines)
+            xline(xlines(v)/binsize);
         end
-        hline(0);
+        yline(0);
         axis tight
         title(binfigname)
     end

--- a/plotting/plot_centering_f0.m
+++ b/plotting/plot_centering_f0.m
@@ -48,9 +48,11 @@ for s=1:length(svec)
             subplot(1,2,1)
             hold on;
             plot(initf0norm(pph),'ro')
-            hline(dinit.pph,'k','--'); hline(-dinit.pph,'k','--');
+            yline(dinit.pph,'Color','k','LineStyle','--');
+            yline(-dinit.pph,'Color','k','LineStyle','--');
             plot(midf0norm(pph),'k.')
-            hline(dmid.pph,'k'); hline(-dmid.pph,'k');
+            yline(dmid.pph,'Color','k');
+            yline(-dmid.pph,'Color','k');
             
             for i=1:length(fpph)
                 plot([i i],[initf0norm(fpph(i)) midf0norm(fpph(i))], 'r-')
@@ -60,14 +62,16 @@ for s=1:length(svec)
             box off
             axis square
             ax = axis;
-            hline(0,'r');
+            yline(0,'Color','r');
             
             subplot(1,2,2)
             hold on;
             plot(initf0norm(cen),'go')
-            hline(dinit.cen,'k','--'); hline(-dinit.cen,'k','--');
+            yline(dinit.cen,'Color','k','LineStyle','--');
+            yline(-dinit.cen,'Color','k','LineStyle','--');
             plot(midf0norm(cen),'k.')
-            hline(dmid.cen,'k'); hline(-dmid.cen,'k');
+            yline(dmid.cen,'Color','k');
+            yline(-dmid.cen,'Color','k');
             
             for i=1:length(fcen)
                 plot([i i],[initf0norm(fcen(i)) midf0norm(fcen(i))], 'g-')
@@ -77,7 +81,7 @@ for s=1:length(svec)
             box off
             axis square
             axis(ax);
-            hline(0,'g');
+            yline(0,'Color','g');
             
             set(gcf,'Position',[265 355 820 299],'Name',sprintf('subj %d %s %d (%s)',snum,condtype,v,conds{v}))
         end
@@ -97,9 +101,11 @@ for s=1:length(svec)
             subplot(1,2,1)
             hold on;
             plot(initf0norm_pph_sorted,'ro')
-            hline(dinit.pph,'k','--'); hline(-dinit.pph,'k','--');
+            yline(dinit.pph,'Color','k','LineStyle','--');
+            yline(-dinit.pph,'Color','k','LineStyle','--');
             plot(midf0norm_pph_sorted,'k.')
-            hline(dmid.pph,'k'); hline(-dmid.pph,'k');
+            yline(dmid.pph,'Color','k');
+            yline(-dmid.pph,'Color','k');
             
             for i=1:length(initf0norm_pph_sorted)
                 plot([i i],[initf0norm_pph_sorted(i) midf0norm_pph_sorted(i)], 'r-')
@@ -109,14 +115,16 @@ for s=1:length(svec)
             box off
             axis square
             ax = axis;
-            hline(0,'r');
+            yline(0,'Color','r');
             
             subplot(1,2,2)
             hold on;
             plot(initf0norm_cen_sorted,'go')
-            hline(dinit.cen,'k','--'); hline(-dinit.cen,'k','--');
+            yline(dinit.cen,'Color','k','LineStyle','--');
+            yline(-dinit.cen,'Color','k','LineStyle','--');
             plot(midf0norm_cen_sorted,'k.')
-            hline(dmid.cen,'k'); hline(-dmid.cen,'k');
+            yline(dmid.cen,'Color','k');
+            yline(-dmid.cen,'Color','k');
             
             for i=1:length(initf0norm_cen_sorted)
                 plot([i i],[initf0norm_cen_sorted(i) midf0norm_cen_sorted(i)], 'g-')
@@ -126,7 +134,7 @@ for s=1:length(svec)
             box off
             axis square
             axis(ax);
-            hline(0,'g');
+            yline(0,'Color','g');
             
             set(gcf,'Position',[265 355 820 299],'Name',sprintf('subj %d %s %d (%s)',snum,condtype,v,conds{v}))
         end

--- a/plotting/plot_ecog_avgByChan.m
+++ b/plotting/plot_ecog_avgByChan.m
@@ -48,7 +48,7 @@ for i=1:nplots
         set(gca,'XTickLabel',[]);
         title(num2str(chnums(i)))
     end
-    vline(.475,'k');
+    xline(.475,'Color','k');
 end
 
 set(gcf,'MenuBar','none')
@@ -66,7 +66,7 @@ for j=1:ngroups
     plot(t,sig,'Color',colors{j});
     %set(gca,'XTickLabel',[]);
     title(inputname(3))
-    %vline(0,'k');
+    %xline(0,'Color','k');
     box off;
     xlabel('time (s)')
 end

--- a/plotting/plot_ecog_raster.m
+++ b/plotting/plot_ecog_raster.m
@@ -34,13 +34,13 @@ for i=1:nplots
     title(fns{i})
     colormap(cmaps{i});
     freezeColors
-    vline(100,'w','--');
+    xline(100,'Color','w','LineStyle','--');
     %subplot(nrows,nplots,(nrows-1)*nplots+i)
     subplot(nrows,nplots,(nrows-1)*nplots+1:nrows*nplots)
     plot(nanmean(chdata(trialinds,1:300)),'color',colors{i});
     hold on;
 end
-vline(100,'k');
+xline(100,'Color','k');
 set(gcf,'MenuBar','none')
 set(gcf,'Position',pos)
 

--- a/plotting/plot_ecog_raster2.m
+++ b/plotting/plot_ecog_raster2.m
@@ -28,7 +28,7 @@ for i=1:nplots
     subplot(nrows,nplots,i:nplots:(nrows-2)*nplots+i)
     imagesc(chdata(trialinds,:));
     title(fns{i})
-    vline(100,'w','--');
+    xline(100,'Color','w','LineStyle','--');
     subplot(nrows,nplots,(nrows-1)*nplots+i)
     % plot center
     sig = chdata(trialinds(1:ceil(length(trialinds)/3)),1:300);
@@ -41,7 +41,7 @@ for i=1:nplots
     plot(nanmean(sig),'color',red,'LineWidth',2);
     err = get_errorbars(sig','se');
     plot_filled_err([],nanmean(sig),err',red);
-    vline(100,'k');
+    xline(100,'Color','k');
 end
 set(gcf,'MenuBar','none')
 set(gcf,'Position',pos)

--- a/plotting/plot_fmtMatrix.m
+++ b/plotting/plot_fmtMatrix.m
@@ -79,10 +79,10 @@ for c = 1:length(conds)
     end
 end
 if ~strncmp(toPlot,'raw',3)
-    hline(0,'k');  % draw y = 0 line (if not plotting raw formants)
+    yline(0,'Color','k');  % draw y = 0 line (if not plotting raw formants)
 end
-vline(mean(hashalf_s),'k','--'); % median survival time
-vline(mean(hasquart_s),'k',':'); % 25% survival time
+xline(mean(hashalf_s),'Color','k','LineStyle','--'); % median survival time
+xline(mean(hasquart_s),'Color','k','LineStyle',':'); % 25% survival time
 legend(htracks, conds, 'Location','SouthEast'); legend boxoff;
 xlabel(xlab, 'FontWeight', 'bold', 'FontSize', 11);
 ylabel(ylab, 'FontWeight', 'bold', 'FontSize', 11);

--- a/plotting/plot_fmtMatrix_crossSubj.m
+++ b/plotting/plot_fmtMatrix_crossSubj.m
@@ -137,9 +137,9 @@ for f=1:length(fx)
             %hasquart_s(c) = find(hasquart.(cnd), 1, 'last')*tstep; %#ok<AGROW>            
             
         end
-        hline(0,'k');
+        yline(0,'Color','k');
 
-        %vline(mean(hashalf_s),'k','--');
+        %xline(mean(hashalf_s),'Color','k','LineStyle','--');
         legend(hlin, conds, 'Location','NorthWest'); legend boxoff;
         xlabel(plotParams.xlab, 'FontSize', 20);
         ylabel(ylabs{fn}, 'FontSize', 20);

--- a/plotting/plot_hist_VOT.m
+++ b/plotting/plot_hist_VOT.m
@@ -52,7 +52,7 @@ for w=wordinds
 end
 
 for w=wordinds
-    vline(nanmean(vots{w}),plotcolor{w});
+    xline(mean(vots{w},'omitnan'),'Color',plotcolor{w});
 end
 
 title(sprintf('%s',color))

--- a/plotting/plot_sine_sum.m
+++ b/plotting/plot_sine_sum.m
@@ -42,7 +42,7 @@ h_sum = plot(t,sum(sinewaves),'Color','k','LineWidth',4);
 strs = arrayfun(@num2str, freqs, 'Uniform', false);
 strs{end+1} = 'sum';
 legend(strs,'AutoUpdate','off');
-hline(0,'k');
+yline(0,'Color','k');
 xlabel(sprintf('time (%s)',timeUnits))
 ylabel('amplitude')
 %uistack(h_sum,'bottom');
@@ -65,7 +65,7 @@ if bPlotSep
         ax = nexttile;
         plot(t,sinewaves(s,:),'Color',color,'LineWidth',linewidth,'LineStyle',linestyle);
         hold on;
-        hline(0,'k');
+        yline(0,'Color','k');
         ylabel('amplitude')
         
         ylim(ylims);
@@ -79,7 +79,7 @@ if bPlotSep
     linestyle = h_sum.LineStyle;
     plot(t,sum(sinewaves),'Color',color,'LineWidth',linewidth,'LineStyle',linestyle);
     hold on;
-    hline(0,'k');
+    yline(0,'Color','k');
     xlabel('time (s)')
     ylabel('amplitude')
     box off
@@ -110,7 +110,7 @@ end
 %     linestyle = h_sin(s).LineStyle;
 %     plot(t,sinewaves(s,:),'Color',color,'LineWidth',linewidth,'LineStyle',linestyle);
 %     hold on;
-%     hline(0,'k');
+%     yline(0,'Color','k');
 %     ylabel('amplitude')
 %     %ax(c).XAxis.Visible = 'off';
 %     ax(s).YLim = ylim;
@@ -127,7 +127,7 @@ end
 % linestyle = h_sum.LineStyle;
 % plot(t,sum(sinewaves),'Color',color,'LineWidth',linewidth,'LineStyle',linestyle);
 % hold on;
-% hline(0,'k');
+% yline(0,'Color','k');
 % xlabel('time (s)')
 % ylabel('amplitude')
 % box off

--- a/plotting/vline.m
+++ b/plotting/vline.m
@@ -1,6 +1,15 @@
 function hl = vline(val,color,linestyle,ax)
 % function hl = vline(val,color,linestyle,ax)
 
+% This function draws a vertical line extending to the axis top and
+% bottom limits at runtime. Note that if the axis top-bottom limits are
+% changed later, the line will retain its original limits.
+%
+% If you instead want a vertical line that extends infinitely up and
+% down, use the MATLAB built-in function XLINE. Note that XLINE creates a
+% LineConstant type object, whereas VLINE creates a Line type object, so
+% some object properties may have different names.
+
 if nargin < 4, ax = gca; end
 
 a = axis(ax);
@@ -12,3 +21,5 @@ end
 if nargin >= 3 && ~isempty(linestyle)
   set(hl,'LineStyle',linestyle);
 end
+
+end %EOF

--- a/speech/check_dataVals.m
+++ b/speech/check_dataVals.m
@@ -476,7 +476,7 @@ function update_plots(src,evt)
             xTicks = get(gca,'XTick');
             xTicks = unique(sort([xTicks .04]));
             set(gca,'XTick',xTicks)
-            vline(0.040,'k',':'); 
+            xline(0.040,'Color','k','LineStyle',':'); 
         end
         set(UserData.warnText,'String',[])
         set(UserData.warnPanel,'HighlightColor',[1 1 1])

--- a/speech/parse_expt_audio.m
+++ b/speech/parse_expt_audio.m
@@ -80,7 +80,7 @@ for s=1:ss
         thisUttPlus = utt_samp(s)/dsfact+sampleOffset/dsfact-preUttBuffer_samp/dsfact:utt_samp(s)/dsfact+dur_samp(s)/dsfact+sampleOffset/dsfact+postUttBuffer_samp/dsfact;
         plot_filled_err(thisUttPlus,zeros(1,length(thisUttPlus)),max(abs(y_ksamps(1:hksamps2plot))),[],.2);
     else
-        vline(stim_samp(s)/dsfact+sampleOffset/dsfact,'r');
+        xline(stim_samp(s)/dsfact+sampleOffset/dsfact,'Color','r');
     end
 end
 

--- a/templates/modelExpt/plot_modelExptPaperFigs.m
+++ b/templates/modelExpt/plot_modelExptPaperFigs.m
@@ -52,7 +52,7 @@ if bPlot
     plot(Weight, 'Marker', p.Marker);
     
     % plot other info
-    hline(3000, 'k')
+    yline(3000, 'Color', 'k')
     ylabel('Weight (lbs)')
     title('Car weight')
     makeFig4Screen;
@@ -78,8 +78,8 @@ if bPlot
     %%
     plot(MPG, 'Color', p.LineColor, 'Marker', p.Marker);
     hold on;
-    hline(20, 'k', ':')
-    hline(35, 'k', ':')
+    yline(20, 'Color', 'k', 'LineStyle', ':');
+    yline(35, 'Color', 'k', 'LineStyle', ':');
     
     % plot other info
     ylabel('Miles per gallon')


### PR DESCRIPTION
In short: vline/hline versus xline/yline are very similar, but xline/yline is more full featured. I think we should make these changes to free-speech to "set a good example."

General info about the difference between vline/hline versus xline/yline is below. I intend to share this with lab members later. 

---
### ABOUT HLINE AND VLINE
hline and vline are free-speech functions for drawing horizontal and vertical lines. They're simple, and our code uses them a ton. A common call looks like this: hline(0, 'k', '--') , meaning, make a black horizontal line at zero with the '--' line style.

Two limitations with these functions are:

1. They draw a line that extends to the current axis limits. If you readjust the axis limits after running the function, your line stays in place. See pic # 1 below for an example where I ran hline then shifted the axis limits. This isn't always the desired behavior.
2. Color and LineStyle are the only properties that can be set in the definition call. Other properties have to be done in a separate code call, which means you also need to assign a handle when defining the line, which might be annoying if you just want to make this line once and then forget about it.


### AN ALTERNATIVE FOR MOST SITUATIONS - YLINE AND XLINE
MATLAB has built-in functions yline and xline which behave similarly -- they draw a horizontal or vertical line at a specified value. E.g., yline(0, 'Color', 'k', 'LineStyle', '--') . However, yline and xline use a special object class called LineConstant which extends infinitely and has some different characteristics.

Benefits/differences when using yline and xline:

- If you resize or rescale the axis or plot more data, your line will still span the whole axis
- You can set the Label property if you want to add text beside the line -- see text "region A" in pic # 2 below. Label color and position can be configured with properties. Previously, you'd have to create a Text object and define its position relative to the line object, but they weren't intrinsically linked.
- Allows any number of object properties to be set in the definition
- Can draw multiple lines in one call -- Accepts a vector of values and draws a line at each one (e.g., xline([5 10 15], 'Color', 'k'))
- Defaults to plotting "under" other objects ('Layer' property defaults to 'bottom'), which would normally be our intended behavior. No need to remember to set  uistack(h_line, 'bottom') !
- One goofy use case - You can create a simple band of color by setting a low Alpha (0.2) and high LineWeight (20) -- see red line in pic # 2 below. (If you care about precisely what area is colored, you're still much better off creating patches with fill )

<img width="648" height="506" alt="2026-07-22 14_32_53-old style line stops" src="https://github.com/user-attachments/assets/241d097b-0008-41b1-86cd-9778a194886a" />

<img width="537" height="472" alt="2026-07-22 11_50_59-new style" src="https://github.com/user-attachments/assets/6a4c3a14-6593-40fb-941d-6e666534c2f8" />
